### PR TITLE
Refocus game canvas after panel clicks

### DIFF
--- a/client/src/scenes/TestScene.ts
+++ b/client/src/scenes/TestScene.ts
@@ -186,7 +186,12 @@ export class TestScene extends Phaser.Scene {
         padding:'8px 10px', borderRadius:'6px', border:'1px solid rgba(255,255,255,0.15)',
         background:'rgba(255,255,255,0.08)', color:'#eaeefb', cursor:'pointer'
       } as CSSStyleDeclaration)
-      b.onclick = onclick
+      b.onclick = () => {
+        onclick()
+        // ensure keyboard input stays active after clicking a panel button
+        this.game.canvas.focus()
+      }
+      b.onmousedown = e => e.preventDefault()
       panel.appendChild(b)
       return b
     }


### PR DESCRIPTION
## Summary
- Keep keyboard controls active after using TestScene panel buttons by refocusing the game canvas and preventing button focus

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e181a4f8883218c622f9b12387891