### PR TITLE
Add hero sprite and animations

### DIFF
--- a/client/src/animations/heroAnimations.ts
+++ b/client/src/animations/heroAnimations.ts
@@ -1,0 +1,31 @@
+import Phaser from 'phaser'
+
+export function registerHeroAnimations(scene: Phaser.Scene) {
+  scene.anims.create({
+    key: 'hero-idle-down',
+    frames: [{ key: 'hero', frame: 0 }],
+    frameRate: 1,
+    repeat: -1,
+  })
+
+  scene.anims.create({
+    key: 'hero-walk-down',
+    frames: scene.anims.generateFrameNumbers('hero', { start: 0, end: 2 }),
+    frameRate: 8,
+    repeat: -1,
+  })
+
+  scene.anims.create({
+    key: 'hero-walk-left',
+    frames: scene.anims.generateFrameNumbers('hero', { start: 3, end: 5 }),
+    frameRate: 8,
+    repeat: -1,
+  })
+
+  scene.anims.create({
+    key: 'hero-walk-up',
+    frames: scene.anims.generateFrameNumbers('hero', { start: 6, end: 8 }),
+    frameRate: 8,
+    repeat: -1,
+  })
+}


### PR DESCRIPTION
## Summary
- add helper to register hero idle and walking animations from the hero spritesheet
- spawn hero sprite in PlayScene and TestScene and animate based on movement

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e448a318c83218fb0ab5ad8d85a43