### PR TITLE
Add character generation tests and test harness

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "start": "node dist/index.js",
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run"
   },
   "dependencies": {
     "cors": "^2.8.5",
@@ -21,6 +22,7 @@
     "typescript": "^5.4.5",
     "@types/express": "^4.17.21",
     "@types/ws": "^8.5.10",
-    "@types/node": "^20.11.30"
+    "@types/node": "^20.11.30",
+    "vitest": "^1.6.0"
   }
 }

--- a/server/src/characterGeneration.ts
+++ b/server/src/characterGeneration.ts
@@ -1,0 +1,76 @@
+import type { } from './types/contracts.js';
+
+export interface CharacterParams {
+  heritage?: string;
+}
+
+export interface Character {
+  prompt: string;
+  image: string;
+  params: CharacterParams;
+}
+
+export interface StableDiffusionClient {
+  generate: (prompt: string) => Promise<string>;
+}
+
+export interface Cache {
+  get: (key: string) => Promise<Character | undefined>;
+  set: (key: string, value: Character) => Promise<void>;
+}
+
+export interface ContentFilter {
+  validate: (image: string) => boolean;
+}
+
+export interface FallbackProvider {
+  get: () => Promise<Character>;
+}
+
+interface Deps {
+  stableDiffusion: StableDiffusionClient;
+  cache: Cache;
+  contentFilter: ContentFilter;
+  fallback: FallbackProvider;
+}
+
+export class CharacterGenerator {
+  private queue: Promise<void> = Promise.resolve();
+
+  constructor(private deps: Deps) {}
+
+  assemblePrompt(params: CharacterParams): string {
+    const heritage = params.heritage || 'mystic';
+    return `Portrait of a fantasy game character, heritage: ${heritage}`;
+  }
+
+  private cacheKey(params: CharacterParams): string {
+    return JSON.stringify(params);
+  }
+
+  async generate(params: CharacterParams = {}): Promise<Character> {
+    const prompt = this.assemblePrompt(params);
+    const key = this.cacheKey(params);
+
+    const cached = await this.deps.cache.get(key);
+    if (cached) return cached;
+
+    const run = async (): Promise<Character> => {
+      try {
+        const image = await this.deps.stableDiffusion.generate(prompt);
+        if (!this.deps.contentFilter.validate(image)) {
+          return await this.deps.fallback.get();
+        }
+        const character: Character = { prompt, image, params };
+        await this.deps.cache.set(key, character);
+        return character;
+      } catch {
+        return await this.deps.fallback.get();
+      }
+    };
+
+    const p = this.queue.then(() => run());
+    this.queue = p.then(() => undefined);
+    return p;
+  }
+}

--- a/server/tests/characterGeneration.test.ts
+++ b/server/tests/characterGeneration.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from 'vitest';
+import { CharacterGenerator, Character } from '../src/characterGeneration.js';
+
+function createGenerator() {
+  const store = new Map<string, Character>();
+  const stableDiffusion = { generate: vi.fn() };
+  const cache = {
+    get: vi.fn(async (k: string) => store.get(k)),
+    set: vi.fn(async (k: string, v: Character) => { store.set(k, v); })
+  };
+  const contentFilter = { validate: vi.fn(() => true) };
+  const fallbackChar: Character = { prompt: 'fallback', image: 'fb', params: {} };
+  const fallback = { get: vi.fn(async () => fallbackChar) };
+  const gen = new CharacterGenerator({ stableDiffusion, cache, contentFilter, fallback });
+  return { gen, stableDiffusion, cache, contentFilter, fallback, fallbackChar };
+}
+
+describe('CharacterGenerator', () => {
+  it('assembles prompt with heritage', () => {
+    const { gen } = createGenerator();
+    const prompt = gen.assemblePrompt({ heritage: 'forest' });
+    expect(prompt).toContain('forest');
+    expect(prompt).toContain('Portrait of a fantasy game character');
+  });
+
+  it('uses cache on repeated requests', async () => {
+    const { gen, stableDiffusion } = createGenerator();
+    stableDiffusion.generate.mockResolvedValue('img');
+    await gen.generate({ heritage: 'mountain' });
+    await gen.generate({ heritage: 'mountain' });
+    expect(stableDiffusion.generate).toHaveBeenCalledTimes(1);
+  });
+
+  it('processes requests sequentially via queue', async () => {
+    const { gen, stableDiffusion } = createGenerator();
+    const order: string[] = [];
+    let i = 0;
+    stableDiffusion.generate.mockImplementation(async () => {
+      const idx = ++i;
+      order.push('start' + idx);
+      await new Promise(r => setTimeout(r, 10));
+      order.push('end' + idx);
+      return 'img' + idx;
+    });
+    const p1 = gen.generate({ heritage: 'north' });
+    const p2 = gen.generate({ heritage: 'south' });
+    await Promise.all([p1, p2]);
+    expect(order).toEqual(['start1', 'end1', 'start2', 'end2']);
+  });
+
+  it('returns fallback when generation fails', async () => {
+    const { gen, stableDiffusion, fallback, fallbackChar } = createGenerator();
+    stableDiffusion.generate.mockRejectedValue(new Error('fail'));
+    const result = await gen.generate({ heritage: 'coast' });
+    expect(fallback.get).toHaveBeenCalled();
+    expect(result).toEqual(fallbackChar);
+  });
+
+  it('returns fallback when content filter rejects', async () => {
+    const { gen, stableDiffusion, contentFilter, fallback, fallbackChar } = createGenerator();
+    stableDiffusion.generate.mockResolvedValue('img');
+    contentFilter.validate.mockReturnValue(false);
+    const result = await gen.generate({ heritage: 'plains' });
+    expect(fallback.get).toHaveBeenCalled();
+    expect(result).toEqual(fallbackChar);
+  });
+});


### PR DESCRIPTION
## Summary
- add CharacterGenerator service with prompt assembly, caching, queueing, and fallback logic
- add vitest-based tests for character generation
- wire up `npm test` script using vitest

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e60dcdb188321a5bf745457aeafe4