### PR TITLE
feat: display player portrait in UI overlays

### DIFF
--- a/client/src/playerProfile.ts
+++ b/client/src/playerProfile.ts
@@ -1,0 +1,18 @@
+export type PlayerProfile = {
+  portraitUrl: string | null
+}
+
+export const playerProfile: PlayerProfile = {
+  portraitUrl: null,
+}
+
+export async function loadPlayerProfile(): Promise<void> {
+  try {
+    const res = await fetch('/api/profile')
+    if (!res.ok) throw new Error('bad response')
+    const data = await res.json()
+    playerProfile.portraitUrl = data?.portraitUrl ?? null
+  } catch {
+    playerProfile.portraitUrl = null
+  }
+}

--- a/client/src/scenes/PlayScene.ts
+++ b/client/src/scenes/PlayScene.ts
@@ -1,6 +1,7 @@
 import Phaser from 'phaser'
 import { ChatPanel } from '../ui/ChatPanel'
 import { registerHeroAnimations } from '../animations/heroAnimations'
+import { playerProfile, loadPlayerProfile } from '../playerProfile'
 
 type Enemy = { id:number; node:Phaser.GameObjects.Arc; hp:number; maxHp:number; speed:number }
 type Loot = { id:number; node:Phaser.GameObjects.Rectangle; value:number }
@@ -75,6 +76,10 @@ export class PlayScene extends Phaser.Scene {
       this.chat.addUser(text)
       const reply = await this.askNpc(text)
       this.chat.addNpc(reply || '(no reply)')
+    })
+
+    loadPlayerProfile().then(() => {
+      this.chat.setPortrait(playerProfile.portraitUrl)
     })
 
     // net

--- a/client/src/scenes/TestScene.ts
+++ b/client/src/scenes/TestScene.ts
@@ -3,6 +3,7 @@ import { ChatPanel } from '../ui/ChatPanel'
 import { SkillBar } from '../ui/SkillBar'
 import { getDevConsole } from '../ui/DevConsole'
 import { registerHeroAnimations } from '../animations/heroAnimations'
+import { playerProfile, loadPlayerProfile } from '../playerProfile'
 
 type Enemy = { id:number; node:Phaser.GameObjects.Arc; hp:number; maxHp:number; speed:number; hpBg: Phaser.GameObjects.Rectangle; hpFg: Phaser.GameObjects.Rectangle }
 type Loot  = { id:number; node:Phaser.GameObjects.Rectangle; value:number }
@@ -135,6 +136,11 @@ export class TestScene extends Phaser.Scene {
     ])
     this.skillBar.setCooldown(0, this.cdSkill1)
       this.skillBar.setCooldown(1, this.cdSkill2)
+
+    loadPlayerProfile().then(() => {
+      this.chat.setPortrait(playerProfile.portraitUrl)
+      this.skillBar.setPortrait(playerProfile.portraitUrl)
+    })
 
     // entities store
     this.bullets = []

--- a/client/src/ui/ChatPanel.ts
+++ b/client/src/ui/ChatPanel.ts
@@ -6,6 +6,9 @@ export class ChatPanel {
   private root: HTMLDivElement
   private logEl: HTMLDivElement
   private inputEl: HTMLInputElement
+  private portraitWrap: HTMLDivElement
+  private portraitImg: HTMLImageElement
+  private portraitPh: HTMLDivElement
   private open = false
   private onSend: SendHandler | null = null
 
@@ -21,6 +24,30 @@ export class ChatPanel {
       fontSize: '14px', boxShadow: '0 6px 24px rgba(0,0,0,0.35)',
       backdropFilter: 'blur(4px)', gap: '8px', zIndex: '10000'
     } as CSSStyleDeclaration)
+
+    const header = document.createElement('div')
+    Object.assign(header.style, { display: 'flex', gap: '8px', alignItems: 'center' } as CSSStyleDeclaration)
+
+    this.portraitWrap = document.createElement('div')
+    Object.assign(this.portraitWrap.style, {
+      width: '48px', height: '48px', borderRadius: '50%', overflow: 'hidden',
+      background: 'rgba(255,255,255,0.08)', display: 'flex', alignItems: 'center', justifyContent: 'center'
+    } as CSSStyleDeclaration)
+
+    this.portraitImg = new Image(48, 48)
+    Object.assign(this.portraitImg.style, { display: 'none', objectFit: 'cover' } as CSSStyleDeclaration)
+    this.portraitWrap.appendChild(this.portraitImg)
+
+    this.portraitPh = document.createElement('div')
+    this.portraitPh.textContent = '…'
+    Object.assign(this.portraitPh.style, {
+      color: '#889', fontSize: '20px', display: 'flex', alignItems: 'center', justifyContent: 'center',
+      width: '100%', height: '100%'
+    } as CSSStyleDeclaration)
+    this.portraitWrap.appendChild(this.portraitPh)
+
+    header.appendChild(this.portraitWrap)
+    this.root.appendChild(header)
 
     this.logEl = document.createElement('div')
     Object.assign(this.logEl.style, {
@@ -65,6 +92,7 @@ export class ChatPanel {
     document.body.appendChild(this.root)
 
     this.addSystem('Press C to toggle chat. Ask for a quest or hint!')
+    this.setPortrait(null)
   }
 
   setOnSend(handler: SendHandler) { this.onSend = handler }
@@ -79,6 +107,24 @@ export class ChatPanel {
     Object.assign(line.style, { alignSelf: 'center', opacity: '0.8', fontSize: '12px' } as CSSStyleDeclaration)
     line.textContent = text
     this.logEl.appendChild(line); this.logEl.scrollTop = this.logEl.scrollHeight
+  }
+
+  setPortrait(url: string | null) {
+    if (url) {
+      this.portraitImg.src = url
+      this.portraitImg.onload = () => {
+        this.portraitImg.style.display = 'block'
+        this.portraitPh.style.display = 'none'
+      }
+      this.portraitImg.onerror = () => {
+        this.portraitImg.style.display = 'none'
+        this.portraitPh.style.display = 'flex'
+      }
+    } else {
+      this.portraitImg.src = ''
+      this.portraitImg.style.display = 'none'
+      this.portraitPh.style.display = 'flex'
+    }
   }
 
   private addBubble(text: string, isUser: boolean) {

--- a/client/src/ui/SkillBar.ts
+++ b/client/src/ui/SkillBar.ts
@@ -10,6 +10,9 @@ export class SkillBar {
   private slots: HTMLDivElement[] = []
   private cds: number[] = [] // remaining ms per slot
   private lastTs = performance.now()
+  private portraitWrap: HTMLDivElement
+  private portraitImg: HTMLImageElement
+  private portraitPh: HTMLDivElement
 
   constructor(skills: SkillSlot[]) {
     this.root = document.createElement('div')
@@ -21,6 +24,27 @@ export class SkillBar {
       borderRadius: '10px', color: '#eaeefb', zIndex: 10000,
       fontFamily: 'ui-sans-serif,system-ui', fontSize: '12px', userSelect: 'none'
     } as CSSStyleDeclaration)
+
+    this.portraitWrap = document.createElement('div')
+    Object.assign(this.portraitWrap.style, {
+      width: '56px', height: '56px', borderRadius: '8px', overflow: 'hidden',
+      background: 'rgba(255,255,255,0.08)', display: 'flex', alignItems: 'center', justifyContent: 'center'
+    } as CSSStyleDeclaration)
+    this.portraitWrap.style.pointerEvents = 'none'
+
+    this.portraitImg = new Image(56, 56)
+    Object.assign(this.portraitImg.style, { display: 'none', objectFit: 'cover' } as CSSStyleDeclaration)
+    this.portraitWrap.appendChild(this.portraitImg)
+
+    this.portraitPh = document.createElement('div')
+    this.portraitPh.textContent = '…'
+    Object.assign(this.portraitPh.style, {
+      color: '#889', fontSize: '20px', display: 'flex', alignItems: 'center', justifyContent: 'center',
+      width: '100%', height: '100%'
+    } as CSSStyleDeclaration)
+    this.portraitWrap.appendChild(this.portraitPh)
+
+    this.root.appendChild(this.portraitWrap)
 
     skills.forEach((s, idx) => {
       const slot = document.createElement('div')
@@ -55,6 +79,7 @@ export class SkillBar {
 
     document.body.appendChild(this.root)
     requestAnimationFrame(this.tick)
+    this.setPortrait(null)
   }
 
   // arrow function to preserve this
@@ -70,6 +95,24 @@ export class SkillBar {
       }
     }
     requestAnimationFrame(this.tick)
+  }
+
+  setPortrait(url: string | null) {
+    if (url) {
+      this.portraitImg.src = url
+      this.portraitImg.onload = () => {
+        this.portraitImg.style.display = 'block'
+        this.portraitPh.style.display = 'none'
+      }
+      this.portraitImg.onerror = () => {
+        this.portraitImg.style.display = 'none'
+        this.portraitPh.style.display = 'flex'
+      }
+    } else {
+      this.portraitImg.src = ''
+      this.portraitImg.style.display = 'none'
+      this.portraitPh.style.display = 'flex'
+    }
   }
 
   setCooldown(slotIndex: number, cooldownMs: number) {


### PR DESCRIPTION
## Summary
- Show player portrait with placeholder in chat panel
- Add portrait slot to skill bar and load from player profile
- Load portrait URL from player profile in scenes

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e60dbcccc8321b3db5bd044274b54