### PR TITLE
feat: add character generation route

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -4,6 +4,7 @@ import cors from 'cors';
 import { WebSocketServer } from 'ws';
 import http from 'node:http';
 import { llm, embed, memorySearch, memoryUpsert, stt, tts, genImage} from './routes/ai.js';
+import { generateCharacter } from './routes/character.js';
 
 const PORT = Number(process.env.PORT || 8080);
 const HOST = process.env.HOST || '0.0.0.0';
@@ -21,6 +22,7 @@ app.post('/memory/upsert', memoryUpsert);
 app.post('/stt', stt);
 app.post('/tts', tts);
 app.post('/gen/image', genImage);
+app.post('/character/generate', generateCharacter);
 
 const server = http.createServer(app);
 const wss = new WebSocketServer({ server });

--- a/server/src/routes/ai.ts
+++ b/server/src/routes/ai.ts
@@ -15,7 +15,7 @@ export async function llm(req: Request, res: Response) {
       body: JSON.stringify({ model: 'llama3.1:8b', messages: body.messages, stream: false })
     });
     if (!r.ok) throw new Error('LLM HTTP ' + r.status);
-    const data = await r.json();
+    const data: any = await r.json();
     const text = data?.message?.content || data?.response || '';
     const out: LlmResponse = { text, toolCalls: [] };
     res.json(out);
@@ -33,7 +33,7 @@ export async function embed(req: Request, res: Response) {
       body: JSON.stringify({ model: 'nomic-embed-text', prompt: body.texts.join('\n') })
     });
     if (!r.ok) throw new Error('Embed HTTP ' + r.status);
-    const data = await r.json();
+    const data: any = await r.json();
     const vectors = data?.embedding ? [data.embedding] : body.texts.map(_ => Array(768).fill(0));
     const out: EmbedResponse = { vectors };
     res.json(out);

--- a/server/src/routes/character.ts
+++ b/server/src/routes/character.ts
@@ -1,0 +1,52 @@
+import type { Request, Response } from 'express';
+
+export type CharacterParameters = Record<string, any>;
+
+export type GeneratedCharacter = {
+  portraitUrl: string;
+  parameters: CharacterParameters;
+};
+
+class CharacterGenerator {
+  async generate(parameters?: CharacterParameters): Promise<GeneratedCharacter> {
+    const params = parameters || { seed: Math.floor(Math.random() * 1_000_000) };
+    // Placeholder portrait URL; in real implementation this would point to a generated asset
+    const portraitUrl = 'https://example.com/portrait.png';
+    return { portraitUrl, parameters: params };
+  }
+}
+
+class FallbackManager {
+  async getFallbackCharacter(parameters?: CharacterParameters): Promise<GeneratedCharacter> {
+    const params = parameters || { seed: 0 };
+    const portraitUrl = 'https://example.com/fallback.png';
+    return { portraitUrl, parameters: params };
+  }
+}
+
+class GenerationQueue {
+  private generator: CharacterGenerator;
+
+  constructor() {
+    this.generator = new CharacterGenerator();
+  }
+
+  async requestGeneration(parameters?: CharacterParameters): Promise<GeneratedCharacter> {
+    return this.generator.generate(parameters);
+  }
+}
+
+const generationQueue = new GenerationQueue();
+const fallbackManager = new FallbackManager();
+
+export async function generateCharacter(req: Request, res: Response) {
+  const params = (req.body as CharacterParameters) || undefined;
+  try {
+    const result = await generationQueue.requestGeneration(params);
+    res.json(result);
+  } catch {
+    const fallback = await fallbackManager.getFallbackCharacter(params);
+    res.json(fallback);
+  }
+}
+

--- a/server/src/types/cors.d.ts
+++ b/server/src/types/cors.d.ts
@@ -1,0 +1,1 @@
+declare module 'cors';


### PR DESCRIPTION
## Summary
- add `/character/generate` endpoint with basic generation queue and fallback
- register character generation route in express server
- add simple type stubs and relax JSON typing for build

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e60d8acb08321a059aaca5b3f0bc5