### PR TITLE
feat(server): add character generation queue

### DIFF
--- a/server/src/characters/characterGenerator.ts
+++ b/server/src/characters/characterGenerator.ts
@@ -1,0 +1,14 @@
+import { requestGeneration, GenerationParams } from './generationQueue.js';
+
+export class CharacterGenerator {
+  async generate(params: GenerationParams) {
+    return requestGeneration(params, this.generateImmediate.bind(this));
+  }
+
+  private async generateImmediate(params: GenerationParams) {
+    // Placeholder implementation for character generation logic.
+    return { portrait: null, parameters: params };
+  }
+}
+
+export const characterGenerator = new CharacterGenerator();

--- a/server/src/characters/generationQueue.ts
+++ b/server/src/characters/generationQueue.ts
@@ -1,0 +1,39 @@
+export type GenerationParams = Record<string, any>;
+
+type Job<T> = {
+  params: GenerationParams;
+  generate: (params: GenerationParams) => Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: any) => void;
+};
+
+const maxConcurrent = 3;
+const activeJobs = new Set<Promise<any>>();
+const pendingQueue: Job<any>[] = [];
+
+function processNext() {
+  if (pendingQueue.length === 0) return;
+  if (activeJobs.size >= maxConcurrent) return;
+  const job = pendingQueue.shift()!;
+  run(job);
+}
+
+function run<T>(job: Job<T>) {
+  const p = job.generate(job.params);
+  activeJobs.add(p);
+  p.then(job.resolve, job.reject).finally(() => {
+    activeJobs.delete(p);
+    processNext();
+  });
+}
+
+export function requestGeneration<T>(params: GenerationParams, generate: (params: GenerationParams) => Promise<T>): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const job: Job<T> = { params, generate, resolve, reject };
+    if (activeJobs.size >= maxConcurrent) {
+      pendingQueue.push(job);
+    } else {
+      run(job);
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- add generation queue for character creation
- hook CharacterGenerator into queue processing

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Could not find a declaration file for module 'cors')

------
https://chatgpt.com/codex/tasks/task_e_689e60d463c483219a42c17a3fff53e2