### PR TITLE
Use character modules for generation route

### DIFF
--- a/server/src/routes/character.ts
+++ b/server/src/routes/character.ts
@@ -1,52 +1,39 @@
 import type { Request, Response } from 'express';
+import { characterGenerator } from '../characters/characterGenerator.js';
+import {
+  apiToParams,
+  paramsToCacheKey,
+  type CharacterParameters
+} from '../characters/parameters.js';
+import { ContentFilter } from '../characters/contentFilter.js';
+import { get as cacheGet, store as cacheStore } from '../characters/cache.js';
+import { getFallbackCharacter } from '../characters/fallback.js';
 
-export type CharacterParameters = Record<string, any>;
-
-export type GeneratedCharacter = {
-  portraitUrl: string;
-  parameters: CharacterParameters;
-};
-
-class CharacterGenerator {
-  async generate(parameters?: CharacterParameters): Promise<GeneratedCharacter> {
-    const params = parameters || { seed: Math.floor(Math.random() * 1_000_000) };
-    // Placeholder portrait URL; in real implementation this would point to a generated asset
-    const portraitUrl = 'https://example.com/portrait.png';
-    return { portraitUrl, parameters: params };
-  }
-}
-
-class FallbackManager {
-  async getFallbackCharacter(parameters?: CharacterParameters): Promise<GeneratedCharacter> {
-    const params = parameters || { seed: 0 };
-    const portraitUrl = 'https://example.com/fallback.png';
-    return { portraitUrl, parameters: params };
-  }
-}
-
-class GenerationQueue {
-  private generator: CharacterGenerator;
-
-  constructor() {
-    this.generator = new CharacterGenerator();
-  }
-
-  async requestGeneration(parameters?: CharacterParameters): Promise<GeneratedCharacter> {
-    return this.generator.generate(parameters);
-  }
-}
-
-const generationQueue = new GenerationQueue();
-const fallbackManager = new FallbackManager();
+const filter = new ContentFilter();
 
 export async function generateCharacter(req: Request, res: Response) {
-  const params = (req.body as CharacterParameters) || undefined;
+  const params: CharacterParameters = apiToParams(req.body || {});
+  const cacheKey = paramsToCacheKey(params);
+
+  const cached = await cacheGet(cacheKey);
+  if (cached && typeof (cached as any).portraitUrl === 'string') {
+    res.json({ portraitUrl: (cached as any).portraitUrl, parameters: params });
+    return;
+  }
+
   try {
-    const result = await generationQueue.requestGeneration(params);
-    res.json(result);
+    const result = await characterGenerator.generate(params);
+    const portrait: any = (result as any)?.portrait;
+    if (!portrait) throw new Error('no portrait');
+    if (!filter.validate(portrait)) throw new Error('content rejected');
+
+    const portraitUrl = `data:image/png;base64,${portrait.toString('base64')}`;
+    const out = { portraitUrl, parameters: params };
+    await cacheStore(cacheKey, out);
+    res.json(out);
   } catch {
-    const fallback = await fallbackManager.getFallbackCharacter(params);
-    res.json(fallback);
+    const fallback = getFallbackCharacter(params as any);
+    res.json({ portraitUrl: fallback.portraitUrl || '', parameters: params });
   }
 }
 


### PR DESCRIPTION
## Summary
- Replace inline character generation stubs with imports from dedicated character modules
- Parse API requests into typed parameters and return generated portrait URLs
- Apply caching, content filtering, and fallback presets when generation fails

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f5228f70883219446314370610eb4