### PR TITLE
Use detailed prompts for Stable Diffusion

### DIFF
--- a/server/src/characters/generator.ts
+++ b/server/src/characters/generator.ts
@@ -1,12 +1,6 @@
 import { Buffer } from 'node:buffer';
-
-function buildCharacterPrompt(params: any): string {
-  return 'portrait of a fantasy character';
-}
-
-function buildNegativePrompt(): string {
-  return 'blurry, low quality';
-}
+import { buildCharacterPrompt, buildNegativePrompt } from './prompt.js';
+import type { CharacterParameters } from './parameters.js';
 
 class StableDiffusionClient {
   async generate(opts: { prompt: string; negativePrompt: string; width: number; height: number; guidance: number; steps: number; seed: number }): Promise<Buffer> {
@@ -19,13 +13,13 @@ async function postProcessImage(img: Buffer): Promise<Buffer> {
   return img;
 }
 
-export async function generateCharacter(parameters: any = {}) {
-  const prompt = buildCharacterPrompt(parameters);
+export async function generateCharacter(params: CharacterParameters) {
+  const prompt = buildCharacterPrompt(params);
   const negativePrompt = buildNegativePrompt();
-  const seed = typeof parameters?.artSeed === 'number' ? parameters.artSeed : typeof parameters?.art_seed === 'number' ? parameters.art_seed : typeof parameters?.seed === 'number' ? parameters.seed : Math.floor(Math.random() * 1e9);
+  const seed = typeof params?.artSeed === 'number' ? params.artSeed : Math.floor(Math.random() * 1e9);
   const client = new StableDiffusionClient();
   const raw = await client.generate({ prompt, negativePrompt, width: 512, height: 512, guidance: 7.5, steps: 20, seed });
   const portrait = await postProcessImage(raw);
-  return { portrait, parameters, generatedAt: new Date() };
+  return { portrait, parameters: params, generatedAt: new Date() };
 }
 


### PR DESCRIPTION
## Summary
- Import character prompt builders and parameters
- Generate characters using CharacterParameters and return parameters for caching

## Testing
- `cd server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f549030188321a2b31a04ce28f96f