### PR TITLE
feat: add character fallback manager

### DIFF
--- a/assets/characters/presets/desert_mage_feminine.json
+++ b/assets/characters/presets/desert_mage_feminine.json
@@ -1,0 +1,10 @@
+{
+  "id": "desert_mage_feminine",
+  "name": "Desert Mage",
+  "portraitUrl": "/images/presets/desert_mage.png",
+  "params": {
+    "heritage": "middle_eastern_inspired",
+    "genderExpression": "feminine",
+    "clothingStyle": "robes"
+  }
+}

--- a/assets/characters/presets/forest_rogue_androgynous.json
+++ b/assets/characters/presets/forest_rogue_androgynous.json
@@ -1,0 +1,10 @@
+{
+  "id": "forest_rogue_androgynous",
+  "name": "Forest Rogue",
+  "portraitUrl": "/images/presets/forest_rogue.png",
+  "params": {
+    "heritage": "celtic_inspired",
+    "genderExpression": "androgynous",
+    "clothingStyle": "adventurer"
+  }
+}

--- a/assets/characters/presets/northern_warrior_masculine.json
+++ b/assets/characters/presets/northern_warrior_masculine.json
@@ -1,0 +1,10 @@
+{
+  "id": "northern_warrior_masculine",
+  "name": "Northern Warrior",
+  "portraitUrl": "/images/presets/northern_warrior.png",
+  "params": {
+    "heritage": "nordic_inspired",
+    "genderExpression": "masculine",
+    "clothingStyle": "armored"
+  }
+}

--- a/server/src/characters/characterGenerator.ts
+++ b/server/src/characters/characterGenerator.ts
@@ -1,13 +1,28 @@
 import { requestGeneration, GenerationParams } from './generationQueue.js';
+import { generateCharacter } from './generator.js';
+import ContentFilter from './contentFilter.js';
+import { FallbackManager, fallbackManager as defaultFallback } from './fallback.js';
 
 export class CharacterGenerator {
+  constructor(
+    private filter: ContentFilter = new ContentFilter(),
+    private fallback: FallbackManager = defaultFallback
+  ) {}
+
   async generate(params: GenerationParams) {
     return requestGeneration(params, this.generateImmediate.bind(this));
   }
 
   private async generateImmediate(params: GenerationParams) {
-    // Placeholder implementation for character generation logic.
-    return { portrait: null, parameters: params };
+    try {
+      const result = await generateCharacter(params);
+      if (!this.filter.validate(result.portrait)) {
+        return this.fallback.get(params);
+      }
+      return result;
+    } catch {
+      return this.fallback.get(params);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- add FallbackManager for loading presets and computing closest match
- invoke FallbackManager in character generator whenever generation or content check fails
- seed fallback preset library with common archetypes

## Testing
- `cd server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f55e503388321bc5ac704c645146d