### PR TITLE
Add tier-2 character customization options

### DIFF
--- a/client/src/ui/CharacterCreationScreen.ts
+++ b/client/src/ui/CharacterCreationScreen.ts
@@ -125,11 +125,17 @@ export class CharacterCreationScreen {
     const hairColor = params.hairColor || params.hair_color
     const eyes = params.eyeColor || params.eye_color
     const clothing = params.clothing || params.clothing_style
+    const accessory = Array.isArray(params.accessories) ? params.accessories[0] : params.accessories
+    const expression = params.expression
+    const pose = params.pose
     const parts = [] as string[]
     if (hair) parts.push(`Hair: ${hair}`)
     if (hairColor) parts.push(`Hair Color: ${hairColor}`)
     if (eyes) parts.push(`Eyes: ${eyes}`)
     if (clothing) parts.push(`Clothing: ${clothing}`)
+    if (accessory) parts.push(`Accessory: ${accessory}`)
+    if (expression) parts.push(`Expression: ${expression}`)
+    if (pose) parts.push(`Pose: ${pose}`)
     this.optionsEl.textContent = parts.join(', ')
   }
 

--- a/server/src/characters/parameters.ts
+++ b/server/src/characters/parameters.ts
@@ -77,6 +77,14 @@ export enum EmotionalExpression {
   DETERMINED = 'determined'
 }
 
+export enum Pose {
+  NEUTRAL = 'neutral',
+  ACTION = 'action',
+  GUARD = 'guard',
+  CASUAL = 'casual',
+  HEROIC = 'heroic'
+}
+
 export enum ArtStyle {
   REALISTIC = 'realistic',
   ANIME = 'anime',
@@ -104,6 +112,7 @@ export interface CharacterParameters {
   clothingStyle: OutfitStyle;
   accessories: AccessoryType[];
   expression: EmotionalExpression;
+  pose: Pose;
   artSeed: number;
   styleVariant: ArtStyle;
   qualityLevel: QualityTier;
@@ -122,6 +131,7 @@ export function paramsToCacheKey(p: CharacterParameters): string {
     p.clothingStyle,
     p.accessories.slice().sort().join(','),
     p.expression,
+    p.pose,
     String(p.artSeed),
     p.styleVariant,
     p.qualityLevel
@@ -142,6 +152,7 @@ export function cacheKeyToParams(key: string): CharacterParameters {
     clothingStyle,
     accessories,
     expression,
+    pose,
     artSeed,
     styleVariant,
     qualityLevel
@@ -158,6 +169,7 @@ export function cacheKeyToParams(key: string): CharacterParameters {
     clothingStyle: clothingStyle as OutfitStyle,
     accessories: accessories ? accessories.split(',').filter(Boolean) as AccessoryType[] : [],
     expression: expression as EmotionalExpression,
+    pose: (pose as Pose) || Pose.NEUTRAL,
     artSeed: Number(artSeed) || 0,
     styleVariant: styleVariant as ArtStyle,
     qualityLevel: qualityLevel as QualityTier
@@ -177,6 +189,7 @@ export function paramsToApi(p: CharacterParameters) {
     clothing_style: p.clothingStyle,
     accessories: p.accessories,
     expression: p.expression,
+    pose: p.pose,
     art_seed: p.artSeed,
     style_variant: p.styleVariant,
     quality_level: p.qualityLevel
@@ -196,6 +209,7 @@ export function apiToParams(obj: any): CharacterParameters {
     clothingStyle: obj.clothing_style as OutfitStyle,
     accessories: Array.isArray(obj.accessories) ? obj.accessories as AccessoryType[] : [],
     expression: obj.expression as EmotionalExpression,
+    pose: (obj.pose as Pose) || Pose.NEUTRAL,
     artSeed: Number(obj.art_seed) || 0,
     styleVariant: obj.style_variant as ArtStyle,
     qualityLevel: obj.quality_level as QualityTier

--- a/server/tests/characterRoutes.test.ts
+++ b/server/tests/characterRoutes.test.ts
@@ -51,6 +51,7 @@ const validParams = {
   clothing_style: 'casual',
   accessories: ['scar'],
   expression: 'neutral',
+  pose: 'neutral',
   art_seed: 123,
   style_variant: 'realistic',
   quality_level: 'standard'

--- a/server/tests/parameters.test.ts
+++ b/server/tests/parameters.test.ts
@@ -14,6 +14,7 @@ import {
   OutfitStyle,
   AccessoryType,
   EmotionalExpression,
+  Pose,
   ArtStyle,
   QualityTier,
   type CharacterParameters
@@ -32,6 +33,7 @@ describe('parameter conversions', () => {
     clothingStyle: OutfitStyle.CASUAL,
     accessories: [AccessoryType.SCAR],
     expression: EmotionalExpression.NEUTRAL,
+    pose: Pose.NEUTRAL,
     artSeed: 123,
     styleVariant: ArtStyle.REALISTIC,
     qualityLevel: QualityTier.STANDARD


### PR DESCRIPTION
## Summary
- add facial accessory, expression and pose options to the character customization panel
- wire new options through character generation pipeline and final summary
- introduce `Pose` parameter and update server conversions

## Testing
- `TFJS_NODE_SKIP_PLATFORM_CHECK=1 npm --prefix server test`

------
https://chatgpt.com/codex/tasks/task_e_689f680d78ec8321951b8a0bca2f1262