### PR TITLE
fix: resolve nsfwjs buffer import

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -7,25 +7,28 @@
     "dev": "tsx watch src/index.ts",
     "start": "node dist/index.js",
     "build": "tsc -p tsconfig.json",
-    "test": "vitest run"
+    "test": "vitest run",
+    "postinstall": "patch-package"
   },
   "dependencies": {
-    "cors": "^2.8.5",
-    "express": "^5.1.0",
-    "ws": "^8.17.0",
-    "node-fetch": "^3.3.2",
-    "dotenv": "^17.2.1",
-    "redis": "^5.8.1",
-    "nsfwjs": "^4.2.1",
     "@tensorflow/tfjs-node": "^4.22.0",
-    "sharp": "^0.34.3"
+    "buffer": "^6.0.3",
+    "cors": "^2.8.5",
+    "dotenv": "^17.2.1",
+    "express": "^5.1.0",
+    "node-fetch": "^3.3.2",
+    "nsfwjs": "^4.2.1",
+    "redis": "^5.8.1",
+    "sharp": "^0.34.3",
+    "ws": "^8.17.0"
   },
   "devDependencies": {
+    "@types/express": "^5.0.3",
+    "@types/node": "^24.3.0",
+    "@types/ws": "^8.18.1",
+    "patch-package": "^8.0.0",
     "tsx": "^4.20.4",
     "typescript": "^5.9.2",
-    "@types/express": "^5.0.3",
-    "@types/ws": "^8.18.1",
-    "@types/node": "^24.3.0",
     "vitest": "^3.2.4"
   }
 }

--- a/server/patches/nsfwjs+4.2.1.patch
+++ b/server/patches/nsfwjs+4.2.1.patch
@@ -1,0 +1,26 @@
+diff --git a/node_modules/nsfwjs/dist/cjs/index.js b/node_modules/nsfwjs/dist/cjs/index.js
+index b0f80b3..60b2fc2 100644
+--- a/node_modules/nsfwjs/dist/cjs/index.js
++++ b/node_modules/nsfwjs/dist/cjs/index.js
+@@ -71,7 +71,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
+ exports.NSFWJS = void 0;
+ exports.load = load;
+ var tf = __importStar(require("@tensorflow/tfjs"));
+-var buffer_1 = require("buffer/");
++var buffer_1 = require("node:buffer");
+ var nsfw_classes_1 = require("./nsfw_classes");
+ var availableModels = {
+     MobileNetV2: { numOfWeightBundles: 1 },
+diff --git a/node_modules/nsfwjs/dist/esm/index.js b/node_modules/nsfwjs/dist/esm/index.js
+index 5cd9e37..ebcec24 100644
+--- a/node_modules/nsfwjs/dist/esm/index.js
++++ b/node_modules/nsfwjs/dist/esm/index.js
+@@ -44,7 +44,7 @@ var __spreadArray = (this && this.__spreadArray) || function (to, from, pack) {
+     return to.concat(ar || Array.prototype.slice.call(from));
+ };
+ import * as tf from "@tensorflow/tfjs";
+-import { Buffer } from "buffer/";
++import { Buffer } from "node:buffer";
+ import { NSFW_CLASSES } from "./nsfw_classes.js";
+ var availableModels = {
+     MobileNetV2: { numOfWeightBundles: 1 },

--- a/server/src/characters/contentFilter.ts
+++ b/server/src/characters/contentFilter.ts
@@ -1,6 +1,6 @@
 import type { Buffer } from 'node:buffer';
 import * as tf from '@tensorflow/tfjs-node';
-import nsfwjs from 'nsfwjs';
+import * as nsfwjs from 'nsfwjs';
 import sharp from 'sharp';
 
 class NSFWDetector {


### PR DESCRIPTION
## Summary
- ensure nsfwjs resolves Node's Buffer module via patch-package
- add postinstall hook and buffer dependency
- import nsfwjs using namespace import to match ESM exports

## Testing
- `npm run build`
- `npm test` *(fails: The requested module '../characters/fallback.js' does not provide an export named 'getFallbackCharacter')*

------
https://chatgpt.com/codex/tasks/task_e_689f73f937a883218d0ab4612166eba1