### PR TITLE
fix: export fallback character helper

### DIFF
--- a/server/src/characters/fallback.ts
+++ b/server/src/characters/fallback.ts
@@ -72,4 +72,7 @@ export class FallbackManager {
 }
 
 export const fallbackManager = new FallbackManager();
+export function getFallbackCharacter(params: CharacterParams): CharacterPreset {
+  return fallbackManager.get(params);
+}
 export default FallbackManager;


### PR DESCRIPTION
## Summary
- export `getFallbackCharacter` from fallback character module

## Testing
- `npm test`
- `npm run build` *(fails: TS2322 type incompatibility)*

------
https://chatgpt.com/codex/tasks/task_e_689f77ff7a0c8321a73a2259011f6deb