### PR TITLE
docs: add asset catalog and cross-reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ This repository ships with **Arcane Forge**, the local development environment f
 
 See the [API reference](docs/API.md) for available REST routes and WebSocket messages.
 
+For component metadata and images used throughout the world, consult the
+[asset catalog](docs/asset-catalog.md).
+
 ## Run (Arcane Forge)
 1) Server
    ```bash

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -7,7 +7,7 @@ This document outlines the game design for Arcane Realms.
 ### Dynamic Visual Environment
 The world features **AI-generated environmental assets** that adapt to biome, history, and context:
 
-- **Base Component System**: Foundational assets (walls, houses, farmland) serve as templates for generation
+- **Base Component System**: Foundational assets (walls, houses, farmland) serve as templates for generation and are detailed in [asset-catalog.md](asset-catalog.md)
 - **Contextual Adaptation**: Stable Diffusion transforms base assets to match biome characteristics
   - Forest walls become vine-covered stone with moss and climbing plants
   - Desert houses transform into weathered adobe with sun-bleached textures

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -21,7 +21,7 @@ This document outlines a phased plan for building Arcane Realms from a minimum 
 - [ ] **Creature capture** and basic **player breeding** (UI for combining two creatures and viewing offspring).
 - [ ] Background **wild breeding** ticks (5–15 s) with population caps per cell.
 - [ ] Add an **asset generation queue** for icons/portraits via SDXL; cache by content hash.
-- [ ] Implement **dynamic environment system** with base asset library and biome-specific Stable Diffusion transformations.
+- [ ] Implement **dynamic environment system** with base asset library and biome-specific Stable Diffusion transformations (see [asset-catalog.md](asset-catalog.md)).
 - [ ] Support **multi‑zone** deployment; route players to a zone; persist state per zone.
 - [ ] Sticky routing at the gateway to keep players on the same zone while exploring.
 

--- a/docs/arcane-forge.md
+++ b/docs/arcane-forge.md
@@ -80,7 +80,9 @@ outward.
 ## Environment Design Tools
 To author Realm Tiles, designers begin with a single **seamless 1024 × 1024**
 ground image—such as a field or desert—and layer objects from a component
-library on top (see [environment-builder.md](environment-builder.md)). Each
+library on top (see [environment-builder.md](environment-builder.md)). Asset
+definitions originate from the shared [asset-catalog.md](asset-catalog.md)
+and its companion SQLite database (`ops/data/assets.db`). Each
 object includes metadata, including a collision on/off flag. The editor must
 support:
 

--- a/docs/asset-catalog.md
+++ b/docs/asset-catalog.md
@@ -1,0 +1,34 @@
+# Asset Catalog
+
+## Overview
+The asset catalog tracks reusable game objects for the component library. Each entry includes visual and gameplay metadata so assets can be referenced consistently across tools and the runtime.
+
+## Asset Fields
+| Image | Name | Description | Dimensions (px) | Object Type | Default Collision |
+|-------|------|-------------|-----------------|-------------|-------------------|
+| `oak_tree.png` | Oak Tree | Standard deciduous tree used in forest biomes. | 128×256 | vegetation | true |
+| `stone_wall.png` | Stone Wall | Modular wall segment for towns and dungeons. | 64×128 | structure | true |
+| `campfire.png` | Campfire | Small decorative fire source. | 32×32 | decorative | false |
+
+Add new rows as assets are created. Image paths are relative to the project root.
+
+## SQLite Storage
+Asset metadata is stored in a lightweight SQLite database for use by the component library and runtime systems.
+
+```sql
+CREATE TABLE assets (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL,
+    description TEXT,
+    image_path TEXT NOT NULL,
+    width INTEGER NOT NULL,
+    height INTEGER NOT NULL,
+    object_type TEXT NOT NULL,
+    default_collision INTEGER NOT NULL CHECK (default_collision IN (0,1))
+);
+```
+
+Populate the table from `asset-catalog.md` or import directly via tooling. The database file lives under `ops/data/assets.db` and is loaded at startup by the component library.
+
+## Usage
+The environment builder and world generation pipelines read from the SQLite database to retrieve asset definitions. See the referenced documents for how assets are applied in each system.

--- a/docs/dynamic-assets.md
+++ b/docs/dynamic-assets.md
@@ -19,6 +19,11 @@ Arcane Realms employs an **AI-powered dynamic asset generation system** using St
 
 ## Base Asset Library
 
+The foundational assets are cataloged in
+[asset-catalog.md](asset-catalog.md) and mirrored in a SQLite database
+(`ops/data/assets.db`) so generation and gameplay systems share the same
+authoritative metadata.
+
 ### Architectural Foundation
 ```
 Building Components

--- a/docs/environment-builder.md
+++ b/docs/environment-builder.md
@@ -42,7 +42,9 @@ space of ~1000 ft per side, combine tiles in a **4 × 4 grid** (16 tiles t
 ## Component Library
 The test tool exposes the core pieces used in world generation. Components are
 layered over the background image and include metadata, such as whether
-collision is enabled:
+collision is enabled. The authoritative list of components lives in
+[asset-catalog.md](asset-catalog.md) and is mirrored in a SQLite database
+(`ops/data/assets.db`) that the editor reads on startup:
 - Trees and bushes
 - Walls and fences
 - Houses and doors

--- a/docs/world-generation.md
+++ b/docs/world-generation.md
@@ -75,7 +75,10 @@ the player’s immediate surroundings.
 Arcane Realms features a **dynamic visual environment** where the world's appearance adapts to its biome, history, and current state through AI-generated imagery. Rather than using static, pre-made assets, the game employs **Stable Diffusion** to create contextually appropriate visuals that maintain gameplay functionality while providing infinite visual variety.
 
 ### Base Component Library
-The system starts with a **foundational asset library** of core structural elements:
+The system starts with a **foundational asset library** of core structural
+elements tracked in [asset-catalog.md](asset-catalog.md) and stored in a
+SQLite database (`ops/data/assets.db`) for fast lookup by generation
+pipelines:
 
 #### Architectural Components
 - **Walls**: Stone walls, wooden walls, brick walls, metal barriers


### PR DESCRIPTION
## Summary
- add `asset-catalog.md` with core asset list and SQLite schema
- reference asset catalog from environment builder, dynamic asset system, world generation, arcane forge, and other docs
- link catalog in README and roadmap for cohesive documentation

## Testing
- `npm test` (server)
- `npm test` (client) *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689f895d38148321b9032fbe6f515e11