### PR TITLE
docs: add TODOs for missing details

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,10 +5,13 @@ This project uses separate client and server packages built with
 [Phaser](https://phaser.io/) and Node.js. The guidelines below explain how to
 get set up and how to contribute effectively.
 
+> **TODO:** Add a code of conduct link and expectations for community behavior.
+
 ## Requirements
 - Node.js **18+** is required for both the client and server (Vite 5 and other
 dependencies require Node 18 or newer).
 - npm comes bundled with Node; yarn/pnpm are not officially supported.
+> **TODO:** Clarify supported operating systems and development environment setups.
 
 ## Building and Running
 1. **Server**
@@ -38,6 +41,7 @@ dependencies require Node 18 or newer).
 There are currently **no dedicated lint or format scripts**.
 Please run your preferred tooling (e.g. ESLint or Prettier) before committing
 and ensure any generated files are ignored.
+> **TODO:** Provide recommended ESLint/Prettier configurations or shared settings.
 
 ## Branch and Commit Guidelines
 - Create branches from `main` using prefixes such as
@@ -55,6 +59,7 @@ and ensure any generated files are ignored.
 - Link any related GitHub issues in the PR description.
 - At least one maintainer approval is required before merging.
 - Keep PRs focused—smaller, incremental changes are easier to review.
+> **TODO:** Explain required test coverage and link to any CI pipelines.
 
 ## Where to Ask Questions
 - **Issues:** Report bugs or request features at

--- a/README.md
+++ b/README.md
@@ -5,10 +5,14 @@ and keeps the improved input (WASD + arrows + click-to-move; keys cancel click-t
 This repository ships with **Arcane Forge**, the local development environment for Arcane Realms. See
 [docs/arcane-forge.md](docs/arcane-forge.md) for full setup details.
 
+> **TODO:** Add a concise project overview and list of core technologies used.
+
 See the [API reference](docs/API.md) for available REST routes and WebSocket messages.
 
 For component metadata and images used throughout the world, consult the
 [asset catalog](docs/asset-catalog.md).
+
+> **TODO:** Provide links to additional documentation such as contribution guidelines and roadmap.
 
 ## Run (Arcane Forge)
 1) Server

--- a/docs/20k-Scalability.md
+++ b/docs/20k-Scalability.md
@@ -27,8 +27,9 @@
 - Node.js + TypeScript initially; **Go/Rust** microservices for hot paths later.  
 - Each zone simulates gameplay; target **500–2,000 players/zone** depending on density and sim cost.
 
-**World Orchestrator**  
+**World Orchestrator**
 - Assigns players to zones/instances, handles cross-zone transfers, spins/tears zones as caps are hit.
+> **TODO:** Define the orchestrator's implementation language and messaging protocols.
 
 ## 3) State & Persistence
 - **Postgres**: authoritative game state (accounts, inventories, economy), via Prisma.
@@ -38,6 +39,7 @@
 **Backups & Schema**
 - Nightly Postgres snapshots; Milvus collection export; Redis is ephemeral.
 - Migrations managed with Prisma Migrate; versioned collections for Milvus.
+> **TODO:** Document backup restoration procedures and disaster-recovery playbooks.
 
 ## 4) AI Services (Offline-capable)
 - **Ollama** @ `http://localhost:11434`, proxied behind a thin service with per-zone **request queues** and response caching.
@@ -50,6 +52,7 @@
 - Whisper chunks with short PTT windows; transcripts summarized before LLM.
 - TTS: pre-warm voices; dedupe identical lines across players; short lines in combat.
 - SDXL: pre-batch during low load; cache by **content hash**; stream to clients when ready.
+> **TODO:** Include expected hardware specs to meet these budget assumptions.
 
 ## 5) World Slicing to Reach 20k CCU
 - **Realms (macro)**: geographic clusters (e.g., NA/EU/APAC). CCU per realm depends on hardware (e.g., 2k–4k).
@@ -70,6 +73,7 @@
 - **Sim tick**: **20–30 Hz**; **net send**: **10–20 Hz** with delta compression and snapshot packing.
 - Encodings: **FlatBuffers/Protobuf**, bit-packed transforms; optional **zstd** at the gateway.
 - **Anti-cheat**: sanity checks on input rates, server-enforced cooldowns, server damage rolls.
+> **TODO:** Clarify versioning strategy for network protocols and schema evolution.
 
 ## 7) Wildlife & Breeding at Scale
 - **Background sim per cell**: ecological ticks every **5‑15s**; deterministic PRNG per cell.

--- a/docs/API.md
+++ b/docs/API.md
@@ -2,6 +2,8 @@
 
 ## REST Endpoints
 
+> **TODO:** Document authentication requirements, versioning scheme, and rate limits for all endpoints.
+
 ### POST `/llm`
 **Request**
 
@@ -25,6 +27,7 @@
 |-------|------|-------------|
 | `text` | string | Model reply |
 | `toolCalls`? | { name: string; args: any }[] | Tool call results |
+> **TODO:** List possible error codes and retry behavior for this endpoint.
 
 ### POST `/embed`
 **Request**
@@ -38,6 +41,7 @@
 | Field | Type | Description |
 |-------|------|-------------|
 | `vectors` | number[][] | Embedding vectors |
+> **TODO:** Clarify vector dimensionality and embedding model used.
 
 ### POST `/memory/search`
 **Request**
@@ -54,6 +58,7 @@
 | Field | Type | Description |
 |-------|------|-------------|
 | `hits` | { doc: object; score: number }[] | Matching documents |
+> **TODO:** Specify index consistency guarantees and latency expectations.
 
 ### POST `/memory/upsert`
 **Request**
@@ -68,6 +73,7 @@
 | Field | Type | Description |
 |-------|------|-------------|
 | `ok` | boolean | Upsert success flag |
+> **TODO:** Describe concurrency handling and conflict resolution strategies.
 
 ### POST `/stt`
 **Request**
@@ -75,6 +81,7 @@
 | Field | Type | Description |
 |-------|------|-------------|
 | `audioWavBase64` | string | Base64 WAV audio |
+> **TODO:** Note supported audio formats and maximum payload sizes.
 
 **Response**
 
@@ -94,6 +101,7 @@
 | Field | Type | Description |
 |-------|------|-------------|
 | `audioWavBase64` | string | Base64 WAV audio |
+> **TODO:** Document voice selection parameters and output encoding options.
 
 ### POST `/gen/image`
 **Request**
@@ -108,8 +116,11 @@
 |-------|------|-------------|
 | `imagePngBase64` | string | Base64 PNG image |
 | `assetKey` | string | Identifier for caching |
+> **TODO:** Include information on image resolution limits and processing timeouts.
 
 ## WebSocket Messages
+
+> **TODO:** Outline handshake procedure, reconnection strategy, and message signing or encryption plans.
 
 ### `move`
 Client → Server payload:

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -2,6 +2,8 @@
 
 This document outlines the game design for Arcane Realms.
 
+> **TODO:** Add an overview of the full technology stack (engines, frameworks, languages) to give contributors context on how the design maps to implementation.
+
 #### Dynamic Content**: Points of interest, dungeons, and special locations are generated based on player actions and exploration patterns
 
 ### Dynamic Visual Environment
@@ -15,12 +17,14 @@ The world features **AI-generated environmental assets** that adapt to biome, hi
 - **Historical Layering**: Assets reflect age, player traffic, and regional events
 - **Functional Preservation**: Generated assets maintain gameplay clarity and mechanical function
 - **Smart Caching**: Content-hashed assets ensure consistency while preventing redundant generation## AI‑Driven NPCs
+> **TODO:** Document the image-generation pipeline and asset storage strategy, including any preprocessing steps or CDN usage.
 
 ### Core AI Systems
 - NPCs use **Ollama** via the server's `/llm` endpoint for natural language dialogue.
 - Each NPC has a **persona prompt**, context about the world, and access to a **function‑calling schema** to perform game actions (grant quests, unlock skills, give lore).
 - NPC memory is stored in **Milvus**; queries retrieve relevant dialogue history or lore to inform responses.
 - STT (Whisper) and TTS (Piper) are used to enable voice chat with NPCs when available.
+> **TODO:** Specify fallback behavior when AI services are unavailable and how network errors are surfaced to players.
 
 ### Quest System & Player Tracking
 - **Cross-Player Awareness**: Quest-giving NPCs maintain awareness of all players who have accepted their quests
@@ -64,12 +68,14 @@ The world features **AI-generated environmental assets** that adapt to biome, hi
     - **1 / Q – Magic Missile**: fires a homing projectile at the locked target or forward if no lock.
     - **2 / E – Arcane Nova**: an area‑of‑effect explosion centered on the player with a short wind‑up and knockback.
     - **3 / R – Heal**: restores health; long cooldown.
-    - **4 / F – Mobility** (future): dash or blink to reposition.
+- **4 / F – Mobility** (future): dash or blink to reposition.
 - **Combat**: Left‑clicking on an enemy both locks the target and immediately casts skill 1. Right‑clicking (or Space) will trigger a basic attack. Holding modifiers will be used for advanced skills later.
+> **TODO:** Clarify controller and mobile input support and how keybinds can be remapped.
 
 ## Camera & View
 
 The game uses a fixed top‑down camera. The camera follows the player smoothly and zooms in/out based on context (e.g., zoom out slightly when many enemies spawn).
+> **TODO:** Describe the camera smoothing and zoom algorithms and any performance considerations.
 
 ## HUD & UI
 
@@ -78,6 +84,7 @@ The game uses a fixed top‑down camera. The camera follows the player smoothly 
 - **Target indicators**: a ring around the locked target and a floating health bar above each enemy.
 - **Chat panel**: toggled with **C**, used to talk to NPCs; integrates with the AI service.
 - **Dev console**: toggled with **~** for debugging; captures logs and errors.
+> **TODO:** Detail the UI framework and accessibility features for HUD elements.
 
 ## Character Creation System
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,6 +2,8 @@
 
 This document outlines a phased plan for building Arcane Realms from a minimum viable product (MVP) to a full multi‑realm deployment supporting tens of thousands of players. Each phase includes key deliverables and example tasks.
 
+> **TODO:** Add estimated timelines and dependencies between phases to aid planning.
+
 ## Phase 0 – MVP (2–4 players)
 
 - [ ] Single authoritative **zone server** with basic WebSocket multiplayer.
@@ -13,6 +15,7 @@ This document outlines a phased plan for building Arcane Realms from a minimum 
 - [ ] **AI-powered character creation** with Stable Diffusion generated portraits and randomization options.
 - [ ] Set up **Milvus** with a tiny bestiary and NPC memory collection.
 - [ ] Local AI stack via `ops/docker-compose.yml` (Ollama, Postgres, Redis, Milvus).
+> **TODO:** Determine success metrics for Phase 0 completion.
 
 ## Phase 1 – Dozens to Hundreds of Players
 
@@ -24,6 +27,7 @@ This document outlines a phased plan for building Arcane Realms from a minimum 
 - [ ] Implement **dynamic environment system** with base asset library and biome-specific Stable Diffusion transformations (see [asset-catalog.md](asset-catalog.md)).
 - [ ] Support **multi‑zone** deployment; route players to a zone; persist state per zone.
 - [ ] Sticky routing at the gateway to keep players on the same zone while exploring.
+> **TODO:** Specify load-testing targets for Phase 1 features.
 
 ## Phase 2 – Thousands of Players
 
@@ -33,6 +37,7 @@ This document outlines a phased plan for building Arcane Realms from a minimum 
 - [ ] Introduce **combat events** and **bosses** with load‑shedding (split instance if threshold).
 - [ ] Implement **per‑zone AI quotas**; shard Milvus collections by zone or realm.
 - [ ] Optimise server code; offload CPU‑intensive tasks (physics, AoE checks) to Rust/Go microservices.
+> **TODO:** Identify profiling tools and benchmarks for performance optimization.
 
 ## Phase 3 – 20 000 Concurrency Target
 
@@ -43,6 +48,7 @@ This document outlines a phased plan for building Arcane Realms from a minimum 
 - [ ] Use a **CDN/object store** for generated assets (portraits, creature images); implement cache invalidation.
 - [ ] Integrate **additional classes** (Warrior, Ranger, Summoner) and cooperative features (dungeons, raids).
 - [ ] Enhance the **breeding ecosystem** with genes for temperament, diet, and new species.
+> **TODO:** Define release criteria and monitoring for multi-realm rollout.
 
 ## Ongoing Tasks
 
@@ -51,3 +57,4 @@ This document outlines a phased plan for building Arcane Realms from a minimum 
 - [ ] Harden security: input validation, rate limiting, anti‑cheat measures.
 - [ ] Continually refine **user experience**: controls, feedback, art direction, accessibility.
 - [ ] Gather **player feedback** through playtests and adjust roadmap accordingly.
+> **TODO:** Outline process for updating the roadmap based on feedback and changing priorities.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -2,12 +2,15 @@
 
 This document explains how to set up the **Arcane Forge** development environment for local development and testing.
 
+> **TODO:** Add a high-level overview diagram of the services started during setup.
+
 ## Prerequisites
 
 - **Node.js v20.x** (LTS) and npm or yarn  
 - **Git** for version control  
-- **Docker** and **docker‑compose** for the offline AI stack  
+- **Docker** and **docker‑compose** for the offline AI stack
 - A working **GPU** is recommended if you plan to run larger models like SDXL
+> **TODO:** Specify minimum hardware requirements and OS compatibility.
 
 Clone the repository:
 
@@ -24,6 +27,8 @@ Install dependencies in the client and server directories:
 cd client && npm install
 cd ../server && npm install
 ```
+
+> **TODO:** Mention any required global npm packages or environment variables.
 
 These commands install the TypeScript build system, Phaser, ws and other runtime dependencies.
 
@@ -42,6 +47,7 @@ This starts the following services (ports exposed on your machine):
 - **Postgres** on `localhost:5432` – game state
 - **Redis** on `localhost:6379` – pub/sub and caches
 - **Milvus** on `localhost:19530` – vector memory (NPC memory, creature lineages)
+> **TODO:** Provide instructions for initializing databases and seeding data after services start.
 
 Stable Diffusion is not part of `docker-compose`. Run it separately if you plan to generate or edit images. See [stable-diffusion.md](stable-diffusion.md) for Windows installation and API options.
 

--- a/docs/arcane-forge.md
+++ b/docs/arcane-forge.md
@@ -6,11 +6,14 @@ brings together the tools needed to build and test new features, including
 character creation and world assembly. This document explains how to set up and
 use Arcane Forge while highlighting the areas that require focused testing.
 
+> **TODO:** Provide architecture diagrams showing how client and server components interact during development.
+
 ## Prerequisites
 - **Node.js v20.x** and npm
 - **Git**
 - **Docker** and **docker-compose** for optional offline AI services
 - A **GPU** is recommended when running large models locally
+> **TODO:** Clarify supported operating systems and any platform-specific caveats for these prerequisites.
 
 ## Setup
 1. Clone the repository:
@@ -45,6 +48,7 @@ npm run dev
 
 - **Server**: http://localhost:8080
 - **Client**: http://localhost:5173
+> **TODO:** Describe how environment variables are managed during local development and testing.
 
 ## Testing
 
@@ -76,6 +80,7 @@ created and stitched seamlessly to the current one. Outer tiles belong to
 progressively harder "rings" radiating from the starting tile; enemies and
 resources scale with distance, encouraging players to grow before venturing
 outward.
+> **TODO:** Document tools or scripts used to generate and validate Realm Tiles automatically.
 
 ## Environment Design Tools
 To author Realm Tiles, designers begin with a single **seamless 1024 × 1024**
@@ -90,6 +95,7 @@ support:
 - Snap-to-grid alignment
 - Export/import of tile data for version control and sharing
 - Previewing neighboring tiles to verify seamless borders
+> **TODO:** Add guidance on exporting/importing tile data formats and version control strategies.
 
 ## Interactive Features
 To prototype gameplay, Arcane Forge includes basic simulation tools:

--- a/docs/asset-catalog.md
+++ b/docs/asset-catalog.md
@@ -3,6 +3,8 @@
 ## Overview
 The asset catalog tracks reusable game objects for the component library. Each entry includes visual and gameplay metadata so assets can be referenced consistently across tools and the runtime.
 
+> **TODO:** Define naming conventions and tagging standards for assets to ensure consistent organization.
+
 ## Asset Fields
 | Image | Name | Description | Dimensions (px) | Object Type | Default Collision |
 |-------|------|-------------|-----------------|-------------|-------------------|
@@ -10,10 +12,14 @@ The asset catalog tracks reusable game objects for the component library. Each e
 | `stone_wall.png` | Stone Wall | Modular wall segment for towns and dungeons. | 64×128 | structure | true |
 | `campfire.png` | Campfire | Small decorative fire source. | 32×32 | decorative | false |
 
+> **TODO:** Add columns for biome affinity, rarity, or interactive properties as needed.
+
 Add new rows as assets are created. Image paths are relative to the project root.
 
 ## SQLite Storage
 Asset metadata is stored in a lightweight SQLite database for use by the component library and runtime systems.
+
+> **TODO:** Document migration procedures when the schema changes.
 
 ```sql
 CREATE TABLE assets (
@@ -29,6 +35,8 @@ CREATE TABLE assets (
 ```
 
 Populate the table from `asset-catalog.md` or import directly via tooling. The database file lives under `ops/data/assets.db` and is loaded at startup by the component library.
+
+> **TODO:** Describe tooling for syncing between the markdown catalog and SQLite database.
 
 ## Usage
 The environment builder and world generation pipelines read from the SQLite database to retrieve asset definitions. See the referenced documents for how assets are applied in each system.

--- a/docs/character-creation.md
+++ b/docs/character-creation.md
@@ -3,6 +3,8 @@
 ## Overview
 Arcane Realms features an **AI-powered character creation system** that uses Stable Diffusion to generate unique character portraits. This system provides infinite variety while maintaining artistic consistency and ensuring all generated content is appropriate for the game's fantasy setting.
 
+> **TODO:** Explain where generated portraits are stored and how long-term caching or CDN distribution is handled.
+
 ## Design Philosophy
 
 ### Player Agency with Guidance
@@ -16,6 +18,7 @@ Arcane Realms features an **AI-powered character creation system** that uses Sta
 - **Quality Assurance**: Automated content filtering and quality validation
 - **Scalability**: System designed to handle high concurrent usage
 - **Fallback Safety**: Graceful degradation when AI services are unavailable
+> **TODO:** Detail moderation policies and tools used for filtering inappropriate content.
 
 ## Character Generation Framework
 
@@ -45,6 +48,8 @@ class CharacterParameters:
     quality_level: QualityTier
 ```
 
+> **TODO:** Define allowable ranges and validation rules for each parameter.
+
 ### Heritage and Cultural Representation
 ```python
 class Heritage(Enum):
@@ -57,6 +62,8 @@ class Heritage(Enum):
     COASTAL_CITIES = "mediterranean_inspired"
     MYSTIC_ENCLAVES = "fantasy_original"
 ```
+
+> **TODO:** Include examples or references for each heritage to guide prompt design.
 
 ### Customization Categories
 

--- a/docs/cleric-skills.md
+++ b/docs/cleric-skills.md
@@ -15,16 +15,20 @@ stateDiagram-v2
 | --- | --- | --- | --- |
 | 1 | Heal | Single-target healing spell | Utility (Healing) |
 
+> **TODO:** Flesh out additional cleric skills and progression tiers beyond Rank 1.
+
 ## Skills
 ### Heal
 - **Cooldown:** 5 s
 - **Healing:** `12 + 3 * INT`
 - **Details:** Single-target heal; can be self-cast.
+> **TODO:** Define casting range and mana cost for Heal.
 
 ## Open Questions
 - What is the casting range for Heal?
 - Should Clerics have additional healing and support abilities?
 - Do critical hits apply to healing spells?
+> **TODO:** Decide whether healing can crit and document the formula if so.
 
 ## Acceptance Criteria
 - Each skill follows the shared state diagram and respects its cooldown.

--- a/docs/client-architecture.md
+++ b/docs/client-architecture.md
@@ -4,12 +4,16 @@
 - **TestScene** – sandbox for skill and UI experiments. It binds movement and skill keys, toggles the in-game DevConsole with the backtick key, and wires up chat and skill cooldown UI.
 - **PlayScene** – main gameplay loop. It handles pointer-based movement and shooting, creates the ChatPanel, and connects to the server over WebSockets to sync other players and enemies.
 
+> **TODO:** Explain how state is managed between scenes and whether a global store (e.g., Redux) is used.
+
 ## UI Components
 - **ChatPanel** – DOM overlay shown with `C`; captures text input and sends it back to the scene via a callback.
 - **SkillBar** – bottom-center HUD that displays skill slots and cooldown fill animations.
 - **DevConsole** – lightweight log viewer toggled with the backtick key; scenes can call `getDevConsole()` to show it.
 
 Scenes create these components and coordinate them—for example, TestScene disables pointer actions while ChatPanel is open and triggers SkillBar cooldowns when spells cast.
+
+> **TODO:** Describe error-handling and logging strategies for UI components.
 
 ## Input → Network → Game Objects
 ```mermaid
@@ -21,13 +25,19 @@ flowchart LR
     Update --> Objects[Game Objects & UI]
 ```
 
+> **TODO:** Clarify message formats and serialization libraries used in WebSocket communication.
+
 ## Extending the Client
 ### Adding a Scene
 1. Create a new class in `client/src/scenes` extending `Phaser.Scene`.
 2. Import and register it in the game config (`client/src/main.ts`).
 3. Reuse helpers like `ChatPanel`, `SkillBar`, or `getDevConsole` as needed.
 
+> **TODO:** Provide conventions for directory structure and naming when adding new scenes or systems.
+
 ### Adding a Skill
 1. Declare a keybinding and add a slot in `SkillBar` (`TestScene.create` shows the pattern).
 2. Implement the ability (e.g., `castMagicMissile` or `castArcaneNova`) and trigger cooldowns through `SkillBar`.
 3. For networked skills, send a message through the scene's WebSocket handler similar to other actions.
+
+> **TODO:** Add guidance on synchronizing client-side prediction with server reconciliation for new skills.

--- a/docs/dynamic-assets.md
+++ b/docs/dynamic-assets.md
@@ -3,6 +3,8 @@
 ## Overview
 Arcane Realms employs an **AI-powered dynamic asset generation system** using Stable Diffusion to create contextually appropriate environmental visuals. This system transforms base architectural and environmental components based on biome characteristics, historical context, and player actions, creating a living world that visually evolves and adapts.
 
+> **TODO:** Add a diagram of the asset-generation pipeline and list external services or libraries required.
+
 ## Core Philosophy
 
 ### Functional Aesthetics
@@ -16,6 +18,7 @@ Arcane Realms employs an **AI-powered dynamic asset generation system** using St
 - **Functional Recognition**: Players can always identify asset types and interactions
 - **Progressive Enhancement**: Base assets provide fallback while enhanced versions generate
 - **Style Persistence**: Generated variations maintain artistic consistency
+> **TODO:** Describe content moderation steps to ensure generated assets remain safe and lore-friendly.
 
 ## Base Asset Library
 
@@ -23,6 +26,8 @@ The foundational assets are cataloged in
 [asset-catalog.md](asset-catalog.md) and mirrored in a SQLite database
 (`ops/data/assets.db`) so generation and gameplay systems share the same
 authoritative metadata.
+
+> **TODO:** Explain how the asset catalog is versioned and synchronized between the database and this document.
 
 ### Architectural Foundation
 ```

--- a/docs/enemy-fsm.md
+++ b/docs/enemy-fsm.md
@@ -12,6 +12,8 @@ stateDiagram-v2
     Recover --> Pursue: Player still in range
 ```
 
+> **TODO:** Describe how the FSM handles multiple players targeting the same enemy.
+
 ## Cooldowns
 - **Wind-up:** 0.5 s telegraph before attack.
 - **Attack:** Instant damage frame.
@@ -24,6 +26,7 @@ stateDiagram-v2
 - Should different enemy types override the default timers?
 - How are interrupts or stuns represented in the state machine?
 - Do ranged enemies share the same state flow or branch after Pursue?
+> **TODO:** Define separate behaviors for ranged and special enemy types.
 
 ## Acceptance Criteria
 - Enemy state transitions follow the diagram above and are driven by timers and player proximity.

--- a/docs/environment-builder.md
+++ b/docs/environment-builder.md
@@ -12,6 +12,8 @@ sandbox where designers can spawn components, experiment with decoration themes,
 and ensure every square connects cleanly to its neighbors. To prototype a play
 space of ~1000 ft per side, combine tiles in a **4 × 4 grid** (16 tiles total).
 
+> **TODO:** Note the technology stack for this editor and any browser requirements.
+
 ## Goals
 - Run independently from the main application, similar to character testing
 - Focus on a single world square while preserving connections to adjacent
@@ -33,11 +35,15 @@ space of ~1000 ft per side, combine tiles in a **4 × 4 grid** (16 tiles t
 - **Drag & Duplicate** for rapid placement of multiples
 - **Snap to Grid** toggle for precise alignment
 
+> **TODO:** Document keyboard shortcuts and UI conventions for these controls.
+
 ### Realm Tile Composition
 - Start with a single 1024 × 1024 seamless ground tile
 - Layer components from the library on top of the background
 - Assign metadata to each object, including collision detection on/off
 - Export to and import from JSON for source control
+
+> **TODO:** Specify the JSON schema and versioning approach for exported tiles.
 
 ## Component Library
 The test tool exposes the core pieces used in world generation. Components are
@@ -52,6 +58,8 @@ collision is enabled. The authoritative list of components lives in
 - Corn fields and farm equipment
 - Additional decorative or functional items as needed
 
+> **TODO:** Clarify how new components are added to the library and synced with the database.
+
 ## Asset Sheet Integration
 - A single static image contains all component sprites with predefined
   coordinates
@@ -59,7 +67,11 @@ collision is enabled. The authoritative list of components lives in
 - Sliced assets feed Stable Diffusion prompts to generate themed variants
 - Generated pieces remain aligned to the grid for seamless square assembly
 
+> **TODO:** Describe how asset variations are cached and reused across sessions.
+
 ## Future Enhancements
 - Connect multiple squares to build larger test scenes
 - Save/load layouts for regression testing
 - Batch-generate random squares to stress test decoration themes
+
+> **TODO:** Investigate collaboration features for multiple designers editing the same scene.

--- a/docs/mage-skills.md
+++ b/docs/mage-skills.md
@@ -33,6 +33,8 @@ stateDiagram-v2
 | 9 | Chain Lightning / Thunderbolt | Bouncing lightning spell | Offense (Damage) |
 | 10 | Time Manipulation | Slow enemies or haste allies | Control / Utility |
 
+> **TODO:** Outline progression tiers and how new mage skills unlock over levels.
+
 ## Skills
 
 ### Magic Missile
@@ -42,6 +44,7 @@ stateDiagram-v2
 - **Mana Cost:** 10
 - **Cast Time:** 1.0 s
 - **Details:** Fires a homing projectile at the target. Cannot miss once cast.
+> **TODO:** Describe projectile speed and interaction with obstacles.
 
 ### Fireball
 - **Cooldown:** 3.0 s
@@ -69,6 +72,7 @@ stateDiagram-v2
 - **Mana Cost:** 35
 - **Cast Time:** 3.0 s (channeled)
 - **Details:** Rapid-fire magical projectiles. Can be interrupted by movement or damage.
+> **TODO:** Specify channel break conditions and whether partial damage is applied on interruption.
 
 ### Summon Elemental
 - **Cooldown:** 45 s
@@ -109,6 +113,7 @@ stateDiagram-v2
 - **Cast Time:** 1.0 s
 - **Duration:** 20 s
 - **Details:** Absorbs `30 + 2 * INT` damage using mana instead of health (2 mana per damage).
+> **TODO:** Define recharge mechanics and interactions with other defensive buffs.
 
 ### Chain Lightning
 - **Cooldown:** 10 s
@@ -153,6 +158,7 @@ stateDiagram-v2
 - What happens when a mage runs out of mana mid-cast?
 - Should area spells have friendly fire considerations?
 - How should line-of-sight affect targeted spells?
+> **TODO:** Decide if terrain and obstacles block spells and include LOS checks in design.
 
 ## Acceptance Criteria
 - Each skill follows the shared state diagram and respects its cooldown

--- a/docs/npc-systems.md
+++ b/docs/npc-systems.md
@@ -3,6 +3,8 @@
 ## Overview
 Arcane Realms features a sophisticated NPC system where characters exhibit realistic behaviors, maintain complex social relationships, and provide dynamic quest content. This document outlines the technical architecture and design principles behind the AI-driven NPC experience.
 
+> **TODO:** Document the runtime frameworks and libraries used to implement these NPC systems.
+
 ## NPC AI Architecture
 
 ### Core AI Components
@@ -32,6 +34,7 @@ NPC AI System
 - **Function Calling**: NPCs can trigger game actions (quest assignment, item trading, skill teaching)
 - **Conversation Memory**: Each interaction is stored and referenced in future conversations
 - **Voice Support**: Optional STT/TTS for immersive voice interactions
+> **TODO:** Explain how dialogue latency is managed and what happens if the LLM service times out.
 
 ## Quest System Architecture
 
@@ -77,6 +80,8 @@ class NPCSchedule:
     special_events: List[ScheduleOverride]
 ```
 
+> **TODO:** Specify the pathfinding algorithm and how movement meshes are generated for NPC navigation.
+
 ### Activity Types
 - **Work**: Profession-based activities (blacksmith, merchant, guard)
 - **Social**: Visiting friends, attending events, casual conversations
@@ -103,6 +108,8 @@ class NPCRelationship:
     shared_interests: List[Topic]
     conversation_frequency: float
 ```
+
+> **TODO:** Clarify how long-term memory persistence is stored and synchronized across servers.
 
 ### Conversation System
 - **Trigger Conditions**: NPCs converse when paths cross based on relationship and context

--- a/docs/stable-diffusion.md
+++ b/docs/stable-diffusion.md
@@ -2,6 +2,8 @@
 
 Arcane Realms relies on open-source Stable Diffusion services for text-to-image, image-to-image, and inpainting tasks (e.g., redrawing walls, trees, bushes, or houses) on Windows 11 hardware with an RTX 5090 GPU.
 
+> **TODO:** Document steps for Linux/macOS setups and any GPU driver requirements beyond the RTX 5090 example.
+
 ## Available Options
 
 | Service | License | Highlights |
@@ -12,6 +14,7 @@ Arcane Realms relies on open-source Stable Diffusion services for text-to-image,
 | [Diffusers + FastAPI](https://github.com/huggingface/diffusers) | Apache‑2.0 | Build a custom service using Hugging Face Diffusers and FastAPI for maximum control. |
 
 All of these options run locally and satisfy the requirement to use public, free software.
+> **TODO:** Provide guidance on choosing between these services and outline pros/cons for production deployment.
 
 ## Quick Start (Automatic1111 Example)
 
@@ -32,6 +35,7 @@ All of these options run locally and satisfy the requirement to use public, free
 - Install the latest NVIDIA drivers and CUDA toolkit for the RTX 5090.
 - Enable `xformers` or FlashAttention to reduce VRAM usage.
 - SDXL models require roughly 12 GB of VRAM, which fits comfortably on the 5090.
+> **TODO:** Include benchmarks or expected generation times under typical configurations.
 
 ## Tiling Strategy & Scale
 

--- a/docs/test-area.md
+++ b/docs/test-area.md
@@ -2,6 +2,8 @@
 
 The Test Area is a dedicated playground for validating character abilities and enemy behavior before integrating features into the full game. It launches automatically when the client starts and exposes tools for spawning enemies, toggling AI, and testing skills.
 
+> **TODO:** Describe logging or telemetry options for capturing test metrics.
+
 ## Launching
 1. Start the server and client as described in [SETUP.md](SETUP.md).
 2. Open `http://localhost:5173` in a browser. The **TestScene** loads by default.
@@ -16,6 +18,8 @@ The Test Area is a dedicated playground for validating character abilities and e
 - **C:** toggle chat panel
 - **`** (backtick): toggle dev console
 
+> **TODO:** Include controller and mobile input mappings for completeness.
+
 ## Control Panel
 A DOM panel titled **Test Controls** appears in the upper-left and provides buttons to manipulate the scene:
 - **Spawn Enemy** – add one enemy at the test marker
@@ -26,5 +30,9 @@ A DOM panel titled **Test Controls** appears in the upper-left and provides butt
 - **Invincible** – toggle player damage intake
 - **Slow-mo** – toggle time scale for debugging
 
+> **TODO:** Document network simulation tools (latency, packet loss) for multiplayer testing.
+
 ## Focus
 Until core character functionality is complete, all interaction features should be implemented and validated in this Test Area. Use it to iterate quickly on combat, abilities, and enemy AI before promoting changes to other scenes.
+
+> **TODO:** Clarify how test results should be recorded and shared among team members.

--- a/docs/world-generation.md
+++ b/docs/world-generation.md
@@ -3,6 +3,8 @@
 ## Overview
 Arcane Realms features a **player-driven world generation system** where the game world expands dynamically based on player exploration. This document outlines the technical and design aspects of how the world grows, evolves, and maintains performance at scale.
 
+> **TODO:** Describe the persistence layer and how world state is stored and retrieved across sessions.
+
 ## Generation Philosophy
 
 ### Player-Centric Design
@@ -25,6 +27,8 @@ World
 │   └── Regional Themes/Lore
 └── Global World State
 ```
+
+> **TODO:** Clarify which mapping or ECS libraries handle these hierarchical regions.
 
 ### Tile Scale & Seamless Tiling
 
@@ -55,6 +59,8 @@ the player’s immediate surroundings.
 6. **Integration**: Seamlessly connect to existing world
 7. **Activation**: Make available for player exploration
 
+> **TODO:** Specify error-handling and rollback strategies when generation fails.
+
 #### Ground Tile Generation Steps
 1. **Determine Tile Set**: Calculate which 1024 × 1024 tiles (and any 4 × 4 groups)
    are required based on player direction and world coordinates
@@ -73,6 +79,8 @@ the player’s immediate surroundings.
 
 ### AI-Powered Asset Generation
 Arcane Realms features a **dynamic visual environment** where the world's appearance adapts to its biome, history, and current state through AI-generated imagery. Rather than using static, pre-made assets, the game employs **Stable Diffusion** to create contextually appropriate visuals that maintain gameplay functionality while providing infinite visual variety.
+
+> **TODO:** Outline hardware requirements and performance budgets for the generation service.
 
 ### Base Component Library
 The system starts with a **foundational asset library** of core structural


### PR DESCRIPTION
## Summary
- add TODO markers across design, world generation, and other docs to highlight missing technical details and open questions
- flag gaps in API reference, setup guide, and contributor instructions for further clarification

## Testing
- `cd server && npm test`
- `cd ../client && npm test` *(fails: Missing script "test")*
- `npm run build` *(client)*
- `cd ../server && npm run build` *(fails: TypeScript error)*

------
https://chatgpt.com/codex/tasks/task_e_689f8e37fbd48321bf0ec37939e0b20f