### PR TITLE
docs: add setup services diagram

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -2,7 +2,24 @@
 
 This document explains how to set up the **Arcane Forge** development environment for local development and testing.
 
-> **TODO:** Add a high-level overview diagram of the services started during setup.
+During setup you will launch the game client, game server, and several supporting services.
+The diagram below shows how they connect.
+
+```mermaid
+graph TD
+    Client[Client Dev Server]
+    Server[Game Server]
+    Postgres[(Postgres DB)]
+    Redis[(Redis Cache)]
+    Milvus[(Milvus Vector DB)]
+    Ollama[(Ollama LLM Host)]
+
+    Client -->|WebSocket| Server
+    Server --> Postgres
+    Server --> Redis
+    Server --> Milvus
+    Server --> Ollama
+```
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary
- illustrate how client, server, and local AI services connect during setup

## Testing
- `npm test` (server)
- `npm test` (client) *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689fb06053008321b68216b9099f636c