### PR TITLE
docs: add database initialization instructions

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -78,7 +78,18 @@ This starts the following services (ports exposed on your machine):
 - **Postgres** on `localhost:5432` – game state
 - **Redis** on `localhost:6379` – pub/sub and caches
 - **Milvus** on `localhost:19530` – vector memory (NPC memory, creature lineages)
-> **TODO:** Provide instructions for initializing databases and seeding data after services start.
+After the containers are up, initialize the databases:
+
+```sh
+# Create tables and seed demo rows in Postgres
+docker compose exec -T postgres psql -U game -d game < ops/init-postgres.sql
+
+# Create a Milvus collection and insert a sample vector
+pip install pymilvus
+python ops/init-milvus.py
+```
+
+These scripts create the basic Postgres schema and an example Milvus collection with one starter entry.
 
 Stable Diffusion is not part of `docker-compose`. Run it separately if you plan to generate or edit images. See [stable-diffusion.md](stable-diffusion.md) for Windows installation and API options.
 

--- a/ops/init-milvus.py
+++ b/ops/init-milvus.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Initialize Milvus with a sample collection and data."""
+from pymilvus import connections, FieldSchema, CollectionSchema, DataType, Collection, utility
+
+HOST = "localhost"
+PORT = "19530"
+COLLECTION = "npc_memory"
+
+
+def main():
+    try:
+        connections.connect(host=HOST, port=PORT)
+    except Exception as exc:
+        print(f"Could not connect to Milvus: {exc}")
+        return
+
+    if not utility.has_collection(COLLECTION):
+        fields = [
+            FieldSchema(name="id", dtype=DataType.INT64, is_primary=True, auto_id=True),
+            FieldSchema(name="embedding", dtype=DataType.FLOAT_VECTOR, dim=2),
+            FieldSchema(name="content", dtype=DataType.VARCHAR, max_length=512),
+        ]
+        schema = CollectionSchema(fields, "NPC memory store")
+        collection = Collection(COLLECTION, schema)
+    else:
+        collection = Collection(COLLECTION)
+
+    if collection.num_entities == 0:
+        data = [
+            [[0.1, 0.2]],
+            ["The first memory entry"],
+        ]
+        collection.insert(data)
+        collection.flush()
+
+    print(f"Milvus collection '{COLLECTION}' ready with {collection.num_entities} entities")
+
+
+if __name__ == "__main__":
+    main()

--- a/ops/init-postgres.sql
+++ b/ops/init-postgres.sql
@@ -1,0 +1,11 @@
+-- Initialize game database schema and seed data
+
+CREATE TABLE IF NOT EXISTS players (
+    id SERIAL PRIMARY KEY,
+    name TEXT UNIQUE NOT NULL,
+    created_at TIMESTAMP DEFAULT NOW()
+);
+
+-- Seed an initial player for testing
+INSERT INTO players (name) VALUES ('Test Player')
+ON CONFLICT (name) DO NOTHING;


### PR DESCRIPTION
## Summary
- document how to initialize Postgres and Milvus after starting services
- add SQL and Python scripts to create schemas and seed data

## Testing
- `npm test --prefix server`
- `python -m py_compile ops/init-milvus.py`


------
https://chatgpt.com/codex/tasks/task_e_689fb632bc5c8321a431904e55bbe3ea