### PR TITLE
Add standalone Arcane Forge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ Refer to the [contribution guidelines](CONTRIBUTING.md) and [project roadmap](do
    npm i
    npm run dev
    ```
-   Client: http://localhost:5173
+   Game: http://localhost:5173
+   Arcane Forge: http://localhost:5173/forge
 
 3) (Optional) AI services
    ```bash

--- a/client/forge.html
+++ b/client/forge.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width,initial-scale=1"/>
+    <title>Arcane Forge</title>
+    <style>
+      html, body, #app { height: 100%; margin:0; background:#0b0e14; overflow:hidden; position:relative; z-index:1 }
+      .hud { position:fixed; top:8px; left:8px; color:#eaeefb; font-family:ui-sans-serif,system-ui; }
+    </style>
+  </head>
+  <body>
+    <div id="app"></div>
+    <div class="hud" style="pointer-events:none">
+      ARCANE FORGE
+    </div>
+    <script type="module" src="/src/forgeMain.ts"></script>
+  </body>
+</html>
+

--- a/client/src/forgeMain.ts
+++ b/client/src/forgeMain.ts
@@ -1,0 +1,12 @@
+import Phaser from 'phaser'
+import { TestScene } from './scenes/TestScene'
+
+new Phaser.Game({
+  type: Phaser.AUTO,
+  parent: 'app',
+  backgroundColor: '#1a2030',
+  scale: { mode: Phaser.Scale.RESIZE, autoCenter: Phaser.Scale.CENTER_BOTH, width: 960, height: 540 },
+  physics: { default: 'arcade', arcade: { gravity: { y: 0 }, debug: false } },
+  scene: [TestScene]
+})
+

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -195,7 +195,7 @@ npm run dev
 - The **client** runs via Vite on `http://localhost:5173`.
 - The **server** exposes a WebSocket on `ws://localhost:8080` for multiplayer and routes on `http://localhost:8080`.
 
-Open `http://localhost:5173` in a browser to play. The Test Area is available at root.
+Open `http://localhost:5173` in a browser to play. The Test Area is available at `http://localhost:5173/forge`.
 
 ## Environment Variables
 

--- a/docs/arcane-forge.md
+++ b/docs/arcane-forge.md
@@ -62,7 +62,8 @@ npm run dev
 ```
 
 - **Server**: http://localhost:8080
-- **Client**: http://localhost:5173
+- **Game**: http://localhost:5173
+- **Arcane Forge**: http://localhost:5173/forge
  
 Server configuration values are stored in `server/.env`. Start by copying the
 sample file and adjusting settings for your machine:

--- a/docs/test-area.md
+++ b/docs/test-area.md
@@ -6,7 +6,7 @@ The Test Area is a dedicated playground for validating character abilities and e
 
 ## Launching
 1. Start the server and client as described in [SETUP.md](SETUP.md).
-2. Open `http://localhost:5173` in a browser. The **TestScene** loads by default.
+2. Open `http://localhost:5173/forge` in a browser. The **TestScene** loads by default.
 
 ## Controls
 - **Movement:** WASD or arrow keys


### PR DESCRIPTION
## Summary
- Add new Arcane Forge entry point served at `/forge` with its own HTML and TypeScript bootstrap.
- Document the new `/forge` URL in README and developer docs so the forge can be accessed separately from the main game.

## Testing
- `cd server && npm test`
- `cd client && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689fc5f96ca88321b66529f562dc2f9d