### PR TITLE
feat: follow pointer while dragging

### DIFF
--- a/client/src/scenes/PlayScene.ts
+++ b/client/src/scenes/PlayScene.ts
@@ -238,7 +238,14 @@ export class PlayScene extends Phaser.Scene {
     const right = !!(this.cursors.right?.isDown || this.wasd.right?.isDown)
     const up = !!(this.cursors.up?.isDown || this.wasd.up?.isDown)
     const down = !!(this.cursors.down?.isDown || this.wasd.down?.isDown)
-    if ((left || right || up || down) && this.target) this.target = null
+    const usingKeys = left || right || up || down
+    if (usingKeys && this.target) this.target = null
+
+    // continuous pointer tracking while left button held
+    const p = this.input.activePointer
+    if (!usingKeys && p.isDown && p.leftButtonDown() && this.target) {
+      this.target.set(p.worldX, p.worldY)
+    }
 
     let vx = 0, vy = 0
     if (left) vx -= 1; if (right) vx += 1; if (up) vy -= 1; if (down) vy += 1

--- a/client/src/scenes/TestScene.ts
+++ b/client/src/scenes/TestScene.ts
@@ -455,7 +455,14 @@ export class TestScene extends Phaser.Scene {
     const right = !!(this.cursors.right?.isDown || this.wasd.right?.isDown)
     const up = !!(this.cursors.up?.isDown || this.wasd.up?.isDown)
     const down = !!(this.cursors.down?.isDown || this.wasd.down?.isDown)
-    if ((left || right || up || down) && this.targetPos) this.targetPos = null
+    const usingKeys = left || right || up || down
+    if (usingKeys && this.targetPos) this.targetPos = null
+
+    // continuous pointer tracking while left button held
+    const p = this.input.activePointer
+    if (!usingKeys && p.isDown && p.leftButtonDown() && this.targetPos) {
+      this.targetPos.set(p.worldX, p.worldY)
+    }
 
     let vx = 0, vy = 0
     if (left) vx -= 1; if (right) vx += 1; if (up) vy -= 1; if (down) vy += 1


### PR DESCRIPTION
## Summary
- allow the player to continuously update their movement target while holding the left mouse button
- support pointer-drag movement in both PlayScene and TestScene

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689fd1b7661083219602b127a9b2ac60