### PR TITLE
fix: enable asset import save and global dev console

### DIFF
--- a/client/src/forgeMain.ts
+++ b/client/src/forgeMain.ts
@@ -1,6 +1,7 @@
 import Phaser from 'phaser'
 import { ForgeScene } from './scenes/ForgeScene'
 import { setupForgeUI } from './ui/ForgeToolbar'
+import { getDevConsole } from './ui/DevConsole'
 
 const game = new Phaser.Game({
   type: Phaser.AUTO,
@@ -12,4 +13,8 @@ const game = new Phaser.Game({
 
 const forgeScene = game.scene.getScene('ForgeScene') as ForgeScene
 setupForgeUI(forgeScene)
+
+window.addEventListener('keydown', (e) => {
+  if (e.code === 'Backquote') getDevConsole().toggle()
+})
 

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1,6 +1,7 @@
 import Phaser from 'phaser'
 import { PlayScene } from './scenes/PlayScene'
 import { CharacterCreationScreen } from './ui/CharacterCreationScreen'
+import { getDevConsole } from './ui/DevConsole'
 
 function startGame() {
   new Phaser.Game({
@@ -16,9 +17,10 @@ function startGame() {
 // show character creation first
 new CharacterCreationScreen(() => startGame())
 
-// Prevent accidental back nav
+// Prevent accidental back nav and toggle dev console
 window.addEventListener('keydown', (e) => {
   if ((e.altKey && (e.key === 'ArrowLeft' || e.key === 'ArrowRight'))) e.preventDefault()
+  if (e.code === 'Backquote') getDevConsole().toggle()
 })
 
 // Warn on unload

--- a/client/src/ui/ForgeToolbar.ts
+++ b/client/src/ui/ForgeToolbar.ts
@@ -1,6 +1,6 @@
 import { ForgeScene } from '../scenes/ForgeScene'
 
-const API_BASE = import.meta.env.VITE_API_BASE_URL || ''
+const API_BASE = (import.meta.env.VITE_API_BASE_URL as string | undefined) || 'http://localhost:8080'
 
 export function setupForgeUI(scene: ForgeScene) {
   const library = document.getElementById('component-library')!
@@ -76,13 +76,17 @@ export function setupForgeUI(scene: ForgeScene) {
     fd.append('image', file)
     fd.append('name', name)
     fetch(`${API_BASE}/api/assets`, { method: 'POST', body: fd })
-      .then((r) => r.json())
+      .then((r) => {
+        if (!r.ok) throw new Error('upload failed')
+        return r.json()
+      })
       .then((asset) => {
         addComponent(asset)
         importPanel.classList.add('hidden')
         fileInput.value = ''
         nameInput.value = ''
       })
+      .catch((err) => console.error('asset upload failed', err))
   })
 
   document.querySelectorAll('#component-library .component').forEach((el) => {
@@ -92,4 +96,5 @@ export function setupForgeUI(scene: ForgeScene) {
   fetch(`${API_BASE}/api/assets`)
     .then((r) => r.json())
     .then((assets) => assets.forEach(addComponent))
+    .catch((err) => console.error('asset list failed', err))
 }


### PR DESCRIPTION
## Summary
- default asset upload API URL to localhost and surface errors
- allow Backquote key to open DevConsole in main game and forge

## Testing
- `npm test` in `server`
- `npm run build` in `server` *(fails: "Could not find a declaration file for module 'multer'")*
- `npm run build` in `client`


------
https://chatgpt.com/codex/tasks/task_e_689fe569600083218a601971f2f26bac