### PR TITLE
fix: close import panel after saving

### DIFF
--- a/client/src/ui/ForgeToolbar.ts
+++ b/client/src/ui/ForgeToolbar.ts
@@ -82,11 +82,13 @@ export function setupForgeUI(scene: ForgeScene) {
       })
       .then((asset) => {
         addComponent(asset)
+      })
+      .catch((err) => console.error('asset upload failed', err))
+      .finally(() => {
         importPanel.classList.add('hidden')
         fileInput.value = ''
         nameInput.value = ''
       })
-      .catch((err) => console.error('asset upload failed', err))
   })
 
   document.querySelectorAll('#component-library .component').forEach((el) => {


### PR DESCRIPTION
## Summary
- always hide import panel after saving or failed upload

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ff2b9c5bc8321a25daa2e87988fb9