### PR TITLE
Generate icons for uploaded components

### DIFF
--- a/client/src/ui/ForgeToolbar.ts
+++ b/client/src/ui/ForgeToolbar.ts
@@ -23,15 +23,16 @@ export function setupForgeUI(scene: ForgeScene) {
     })
   }
 
-  function addComponent(asset: { name: string; file: string }) {
+  function addComponent(asset: { name: string; file: string; icon?: string }) {
     const div = document.createElement('div')
     div.className = 'component'
     div.draggable = true
     div.dataset.type = asset.name
-    const src = `${API_BASE}/assets/components/images/${asset.file}`
-    div.dataset.src = src
+    const fullSrc = `${API_BASE}/assets/components/images/${asset.file}`
+    const iconSrc = `${API_BASE}/assets/components/images/${asset.icon ?? asset.file}`
+    div.dataset.src = fullSrc
     const img = document.createElement('img')
-    img.src = src
+    img.src = iconSrc
     img.width = 64
     img.height = 64
     div.appendChild(img)

--- a/server/tests/assetsRoutes.test.ts
+++ b/server/tests/assetsRoutes.test.ts
@@ -27,14 +27,16 @@ describe('assets routes', () => {
     const res = await fetch(url + '/api/assets', { method: 'POST', body: fd as any });
     expect(res.status).toBe(200);
     const out = await res.json();
-    expect(out).toEqual({ name: 'test', file: 'test.png' });
+    expect(out).toEqual({ name: 'test', file: 'test.png', icon: 'test-icon.png' });
 
     const metaPath = path.join(tmpBase, 'assets.json');
     const meta = JSON.parse(fs.readFileSync(metaPath, 'utf-8'));
-    expect(meta).toEqual([{ name: 'test', file: 'test.png' }]);
+    expect(meta).toEqual([{ name: 'test', file: 'test.png', icon: 'test-icon.png' }]);
 
     const imgPath = path.join(tmpBase, 'images', 'test.png');
     expect(fs.existsSync(imgPath)).toBe(true);
+    const iconPath = path.join(tmpBase, 'images', 'test-icon.png');
+    expect(fs.existsSync(iconPath)).toBe(true);
 
     server.close();
     delete process.env.ASSET_DIR;


### PR DESCRIPTION
## Summary
- Create 64x64 icon images when assets are uploaded and store them alongside originals
- Update component library UI to use icon images while retaining full-sized paths for placement
- Expand asset route tests to cover icon creation and metadata

## Testing
- `npm --prefix server test`
- `npm --prefix client test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689ff59b72f08321b2798f5631517fd1