### PR TITLE
fix: populate component library dynamically

### DIFF
--- a/client/forge.html
+++ b/client/forge.html
@@ -30,10 +30,7 @@
       <button id="tool-snap" class="active">Snap</button>
       <button id="tool-import">Import</button>
     </div>
-    <div id="component-library">
-      <div class="component" draggable="true" data-type="tree">Tree</div>
-      <div class="component" draggable="true" data-type="rock">Rock</div>
-    </div>
+    <div id="component-library"></div>
     <input type="file" id="asset-file" accept="image/*" style="display:none"/>
     <div id="import-panel" class="hidden">
       <div class="panel">

--- a/client/src/ui/ForgeToolbar.ts
+++ b/client/src/ui/ForgeToolbar.ts
@@ -92,10 +92,6 @@ export function setupForgeUI(scene: ForgeScene) {
       })
   })
 
-  document.querySelectorAll('#component-library .component').forEach((el) => {
-    registerComponent(el as HTMLElement)
-  })
-
   fetch(`${API_BASE}/api/assets`)
     .then((r) => r.json())
     .then((assets) => assets.forEach(addComponent))


### PR DESCRIPTION
## Summary
- remove hardcoded Tree/Rock placeholders from Forge component library
- load asset components dynamically from the asset API

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a09b452b048321a4daa1a9b61eb79b