### PR TITLE
Fix asset list caching so new components appear in library

### DIFF
--- a/server/src/routes/assets.ts
+++ b/server/src/routes/assets.ts
@@ -19,6 +19,8 @@ const META_FILE = path.join(ASSET_DIR, 'assets.json');
 const upload = multer({ dest: path.join(ASSET_DIR, 'tmp') });
 
 router.get('/', (_req, res) => {
+  // Avoid client-side caching so newly uploaded assets are always listed
+  res.set('Cache-Control', 'no-store');
   try {
     const raw = fs.readFileSync(META_FILE, 'utf-8');
     res.json(JSON.parse(raw));

--- a/server/tests/assetsRoutes.test.ts
+++ b/server/tests/assetsRoutes.test.ts
@@ -38,6 +38,12 @@ describe('assets routes', () => {
     const iconPath = path.join(tmpBase, 'images', 'test-icon.png');
     expect(fs.existsSync(iconPath)).toBe(true);
 
+    // ensure GET route returns asset list and disables caching
+    const listRes = await fetch(url + '/api/assets');
+    expect(listRes.headers.get('cache-control')).toBe('no-store');
+    const list = await listRes.json();
+    expect(list).toEqual([{ name: 'test', file: 'test.png', icon: 'test-icon.png' }]);
+
     server.close();
     delete process.env.ASSET_DIR;
   });


### PR DESCRIPTION
## Summary
- prevent client caching for `/api/assets` responses so newly uploaded components show up
- test that asset list endpoint returns uncached results

## Testing
- `cd server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0a3cb7a84832186bf10ea9ab7ce3a