### PR TITLE
Keep component library open with labeled toolbox

### DIFF
--- a/client/forge.html
+++ b/client/forge.html
@@ -10,9 +10,10 @@
       #toolbar { position:fixed; top:8px; left:50%; transform:translateX(-50%); display:flex; gap:8px; z-index:10 }
       #toolbar button { background:#1f2937; color:#eaeefb; border:none; padding:4px 8px; cursor:pointer }
       #toolbar button.active { background:#374151 }
-      #component-library { position:fixed; left:0; right:0; bottom:-140px; height:140px; background:#1f2937; color:#eaeefb; display:flex; gap:8px; padding:8px; transition:bottom .2s; z-index:10 }
-      #component-library.open { bottom:0 }
+      #component-library { position:fixed; left:0; right:0; bottom:0; height:140px; background:#1f2937; color:#eaeefb; display:flex; gap:8px; padding:32px 8px 8px; z-index:10 }
+      #component-library::before { content:'Component Library'; position:absolute; top:8px; left:8px; font-size:12px }
       #component-library .component { width:64px; height:64px; background:#374151; border:1px solid #555; display:flex; align-items:center; justify-content:center; cursor:grab }
+      #component-library .component img { width:100%; height:100%; object-fit:contain; pointer-events:none }
       #import-panel { position:fixed; inset:0; background:rgba(0,0,0,0.7); display:flex; align-items:center; justify-content:center; z-index:20 }
       #import-panel.hidden { display:none }
       #import-panel .panel { background:#1f2937; padding:16px; display:flex; flex-direction:column; gap:8px; color:#eaeefb }
@@ -22,7 +23,6 @@
   <body>
     <div id="app"></div>
     <div id="toolbar">
-      <button id="tool-add">Add</button>
       <button id="tool-zoom-in">+</button>
       <button id="tool-zoom-out">&minus;</button>
       <button id="tool-select" class="active">Select</button>

--- a/client/src/ui/ForgeToolbar.ts
+++ b/client/src/ui/ForgeToolbar.ts
@@ -6,7 +6,6 @@ const API_BASE =
 
 export function setupForgeUI(scene: ForgeScene) {
   const library = document.getElementById('component-library')!
-  const addBtn = document.getElementById('tool-add')!
   const zoomInBtn = document.getElementById('tool-zoom-in')!
   const zoomOutBtn = document.getElementById('tool-zoom-out')!
   const deleteBtn = document.getElementById('tool-delete')!
@@ -37,14 +36,11 @@ export function setupForgeUI(scene: ForgeScene) {
     img.src = iconSrc
     img.width = 64
     img.height = 64
+    img.alt = asset.name
     div.appendChild(img)
     registerComponent(div)
     library.appendChild(div)
   }
-
-  addBtn.addEventListener('click', () => {
-    library.classList.toggle('open')
-  })
 
   zoomInBtn.addEventListener('click', () => {
     scene.cameras.main.setZoom(scene.cameras.main.zoom + 0.25)


### PR DESCRIPTION
## Summary
- Keep the component library visible at the bottom of the Forge and label it for clarity.
- Remove the toggle button so the library stays expanded.
- Ensure thumbnails display properly and include alt text.

## Testing
- `npm run build` (client)
- `npm test` (server)


------
https://chatgpt.com/codex/tasks/task_e_68a0fb13ff4c8321bc7577e2bceb2c08