### PR TITLE
docs: document per-enemy cooldown timers

### DIFF
--- a/docs/enemy-fsm.md
+++ b/docs/enemy-fsm.md
@@ -15,15 +15,35 @@ stateDiagram-v2
 > **TODO:** Describe how the FSM handles multiple players targeting the same enemy.
 
 ## Cooldowns
+Default timers apply to enemies that do not specify their own values:
+
 - **Wind-up:** 0.5 s telegraph before attack.
 - **Attack:** Instant damage frame.
 - **Recover:** 1.0 s before returning to Idle or Pursue.
+
+### Per-enemy configuration
+Each enemy type can override these durations through its configuration. Timers
+are expressed in seconds and are loaded when the enemy instance spawns.
+
+```json
+{
+  "goblin": {
+    "windUp": 0.2,
+    "attack": 0.0,
+    "recover": 0.8
+  },
+  "stoneGolem": {
+    "windUp": 1.2,
+    "attack": 0.3,
+    "recover": 2.0
+  }
+}
+```
 
 ## Damage Formula
 `damage = baseDamage * (1 + 0.1 * enemyLevel)`
 
 ## Open Questions
-- Should different enemy types override the default timers?
 - How are interrupts or stuns represented in the state machine?
 - Do ranged enemies share the same state flow or branch after Pursue?
 > **TODO:** Define separate behaviors for ranged and special enemy types.


### PR DESCRIPTION
## Summary
- clarify default Wind-up, Attack, and Recover timers
- explain per-enemy timer overrides with example config snippet

## Testing
- `npm test` (fails: Could not read package.json)
- `npm test` in `client` (fails: Missing script "test")
- `npm test` in `server`


------
https://chatgpt.com/codex/tasks/task_e_68b1c588762083219f94f394d2c85546