### PR TITLE
Document stun and interrupt states in enemy FSM

### DIFF
--- a/docs/enemy-fsm.md
+++ b/docs/enemy-fsm.md
@@ -10,9 +10,22 @@ stateDiagram-v2
     Attack --> Recover: After hit
     Recover --> Idle: Cooldown over
     Recover --> Pursue: Player still in range
+    WindUp --> Interrupted: Arcane Nova
+    Attack --> Interrupted: Arcane Nova
+    Interrupted --> Recover: Interrupt recovery
+    Idle --> Stunned: Frost Nova / Polymorph
+    Pursue --> Stunned: Frost Nova / Polymorph
+    WindUp --> Stunned: Frost Nova / Polymorph
+    Attack --> Stunned: Frost Nova / Polymorph
+    Recover --> Stunned: Frost Nova / Polymorph
+    Stunned --> Recover: Stun expires
 ```
 
 > **TODO:** Describe how the FSM handles multiple players targeting the same enemy.
+
+### Crowd Control
+- **Stunned:** Triggered by skills like *Frost Nova* or *Polymorph*. The enemy is immobile and unable to act until the effect ends, then transitions to **Recover**.
+- **Interrupted:** Caused by knockback or counter skills such as *Arcane Nova*. The current **WindUp** or **Attack** is canceled and the enemy briefly enters **Interrupted** before moving to **Recover**.
 
 ## Cooldowns
 - **Wind-up:** 0.5 s telegraph before attack.
@@ -24,7 +37,6 @@ stateDiagram-v2
 
 ## Open Questions
 - Should different enemy types override the default timers?
-- How are interrupts or stuns represented in the state machine?
 - Do ranged enemies share the same state flow or branch after Pursue?
 > **TODO:** Define separate behaviors for ranged and special enemy types.
 

--- a/docs/enemy-fsm.md
+++ b/docs/enemy-fsm.md
@@ -24,8 +24,12 @@ stateDiagram-v2
 > **TODO:** Describe how the FSM handles multiple players targeting the same enemy.
 
 ### Crowd Control
-- **Stunned:** Triggered by skills like *Frost Nova* or *Polymorph*. The enemy is immobile and unable to act until the effect ends, then transitions to **Recover**.
-- **Interrupted:** Caused by knockback or counter skills such as *Arcane Nova*. The current **WindUp** or **Attack** is canceled and the enemy briefly enters **Interrupted** before moving to **Recover**.
+- **Stunned:** Triggered by skills like *Frost Nova* or *Polymorph*. The enemy is
+  immobile and unable to act until the effect ends, then transitions to
+  **Recover**.
+- **Interrupted:** Caused by knockback or counter skills such as *Arcane Nova*.
+  The current **WindUp** or **Attack** is canceled and the enemy briefly enters
+  **Interrupted** before moving to **Recover**.
 
 ## Cooldowns
 - **Wind-up:** 0.5 s telegraph before attack.


### PR DESCRIPTION
## Summary
- Expand enemy FSM diagram with Stunned and Interrupted states
- Describe skills like Frost Nova, Polymorph, and Arcane Nova that trigger crowd-control transitions
- Remove open question about representing stuns and interrupts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c5adc4bc8321a07045f1b6758ad7