### PR TITLE
docs: describe ranged enemy aim and shoot states

### DIFF
--- a/docs/enemy-fsm.md
+++ b/docs/enemy-fsm.md
@@ -22,6 +22,24 @@ stateDiagram-v2
 ## Damage Formula
 `damage = baseDamage * (1 + 0.1 * enemyLevel)`
 
+## Ranged Enemy States
+Ranged foes branch into a different attack sequence once they reach
+their desired distance from the player.
+
+- **Aim:** After `Pursue`, a ranged enemy stops to track the player's
+  movement for a short aiming window instead of entering `WindUp`. During
+  this state the enemy cannot move but continuously rotates to keep the
+  player in sight.
+- **Shoot:** When the aim timer completes the enemy fires a projectile in
+  the last tracked direction. This replaces the instant melee `Attack`
+  state and can damage the player from afar.
+
+Unlike melee enemies, ranged units never use the `WindUp`/`Attack`
+combo. They rely on maintaining distance, locking on during `Aim`,
+releasing a projectile during `Shoot`, and then transitioning to
+`Recover` before deciding whether to `Pursue` again or return to
+`Idle`.
+
 ## Open Questions
 - Should different enemy types override the default timers?
 - How are interrupts or stuns represented in the state machine?


### PR DESCRIPTION
## Summary
- document Aim and Shoot states for ranged foes
- note how ranged behaviors replace WindUp/Attack used by melee enemies

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c5bb2af083219524e9692cac3d8d