### PR TITLE
docs: expand cleric skill set with level unlocks

### DIFF
--- a/docs/cleric-skills.md
+++ b/docs/cleric-skills.md
@@ -14,8 +14,20 @@ stateDiagram-v2
 | Rank | Skill Name | Description | Skill Type |
 | --- | --- | --- | --- |
 | 1 | Heal | Single-target healing spell | Utility (Healing) |
+| 2 | Smite | Ranged holy damage spell | Offense (Damage) |
+| 3 | Bless | Temporary stat buff to an ally | Utility (Buff) |
+| 4 | Sanctuary | Protective aura reducing incoming damage | Defense |
+| 5 | Revive | Resurrect a fallen ally | Utility (Healing) |
 
-> **TODO:** Flesh out additional cleric skills and progression tiers beyond Rank 1.
+## Level Unlocks
+
+| Level | Skill Unlocked |
+| --- | --- |
+| 1 | Heal |
+| 3 | Smite |
+| 5 | Bless |
+| 7 | Sanctuary |
+| 10 | Revive |
 
 ## Skills
 ### Heal
@@ -25,6 +37,36 @@ stateDiagram-v2
 - **Mana Cost:** 15
 - **Critical:** Uses standard spell critical chance; critical heals restore 150% of normal healing.
 - **Details:** Single-target heal; can be self-cast.
+
+### Smite
+- **Cooldown:** 6 s
+- **Damage:** `15 + 4 * INT`
+- **Range:** 8 m
+- **Mana Cost:** 20
+- **Details:** Holy bolt that damages a single enemy; deals 25% bonus damage to Undead.
+
+### Bless
+- **Cooldown:** 20 s
+- **Buff:** +10% to all primary attributes
+- **Range:** 6 m
+- **Mana Cost:** 25
+- **Duration:** 10 s
+- **Details:** Enhances an ally's capabilities; does not stack with other Bless effects.
+
+### Sanctuary
+- **Cooldown:** 30 s
+- **Effect:** Reduces incoming damage by 30%
+- **Range:** 4 m
+- **Mana Cost:** 40
+- **Duration:** 8 s
+- **Details:** Creates a protective aura around the target.
+
+### Revive
+- **Cooldown:** 60 s
+- **Healing:** Restores target to 25% health
+- **Range:** 4 m
+- **Mana Cost:** 60
+- **Details:** Brings a fallen ally back to life at reduced health.
 
 ## Open Questions
 - Should Clerics have additional healing and support abilities?


### PR DESCRIPTION
## Summary
- add Smite, Bless, Sanctuary, and Revive to cleric skill list
- document level-based unlock progression for cleric abilities

## Testing
- `npm test --prefix server`
- `npm test --prefix client` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b1cc24ca20832181dadf83053d7f95