### PR TITLE
docs: remove Phaser references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thank you for your interest in improving **Arcane Realms**!
 This project uses separate client and server packages built with
-[Phaser](https://phaser.io/) and Node.js. The guidelines below explain how to
+[LÖVE](https://love2d.org/) and Node.js. The guidelines below explain how to
 get set up and how to contribute effectively.
 
 Please review our [Code of Conduct](CODE_OF_CONDUCT.md). We expect all

--- a/docs/environment-builder.md
+++ b/docs/environment-builder.md
@@ -12,7 +12,7 @@ sandbox where designers can spawn components, experiment with decoration themes,
 and ensure every square connects cleanly to its neighbors. To prototype a play
 space of ~1000 ft per side, combine tiles in a **4 × 4 grid** (16 tiles total).
 
-The game client uses LÖVE, but the environment builder remains a web tool built with **Phaser** for rendering, **React** for the interface, and **Vite** with TypeScript for bundling. The editor runs in modern browsers such as Chrome 118+, Firefox 115+, Safari 17+, and Edge 118+.
+The game client uses LÖVE, while the environment builder is a web tool built with **React** for the interface and **Vite** with TypeScript for bundling. The editor runs in modern browsers such as Chrome 118+, Firefox 115+, Safari 17+, and Edge 118+.
 
 ## Goals
 - Run independently from the main application, similar to character testing

--- a/docs/love-design.md
+++ b/docs/love-design.md
@@ -2,7 +2,7 @@
 
 This document describes the end‑to‑end design for the LÖVE implementation of Arcane Realms. It covers
 module layout, networking, asset requirements, and build instructions so contributors can recreate the
-current Phaser client in native Lua.
+current client in native Lua.
 
 ## 1. Goals
 - Native desktop client using [LÖVE 11.x](https://love2d.org/) for rendering and input.


### PR DESCRIPTION
## Summary
- replace Phaser references with LÖVE across documentation
- update environment builder docs to mention React and Vite without Phaser
- clarify LÖVE client design without referencing former Phaser client

## Testing
- `npm test` (server)
- `npm run build` (client)


------
https://chatgpt.com/codex/tasks/task_e_68b1e7313a088321956430e674b39bc2